### PR TITLE
Avoid crash with on alt+tab(tabbox) view on close it current window

### DIFF
--- a/layers.cpp
+++ b/layers.cpp
@@ -442,6 +442,12 @@ void Workspace::lowerClientRequest(KWin::AbstractClient *c)
 
 void Workspace::restack(AbstractClient* c, AbstractClient* under, bool force)
 {
+    // Do not anything if the clint not in stacks
+    // note: The client maybe is deleting
+    //       When this call is from TabBoxHandlerImpl::restack
+    if (!unconstrained_stacking_order.contains(c))
+        return;
+
     assert(unconstrained_stacking_order.contains(under));
     if (!force && !AbstractClient::belongToSameApplication(under, c)) {
          // put in the stacking order below _all_ windows belonging to the active application


### PR DESCRIPTION
Summary:
When the window is deleting, if the window is the currentClient
of the TabBox, it will try to reset the currentIndex of the TabBox.
If necessary, the TabBox will update the highlighted window,
and if the kwin compositing is closed at this time, the TabBox
will try to call the restack function. The old currentClient is
placed under the new client. This will cause the currentClient
to be destroy to be re-added to the unconstrained_stacking_order
and crash when accessing the object in the unconstrained_stacking_order

BUG: 330965

Test Plan:
Disable Compositing
Show tabbox window
Click the close button on the tabbox to close the currently highlighted window

https://github.com/linuxdeepin/internal-discussion/issues/1333