### PR TITLE
fix: no QtQuick.Controls 2.1 in Qt 5.7.x

### DIFF
--- a/effects/desktopgrid/main.qml
+++ b/effects/desktopgrid/main.qml
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *********************************************************************/
 import QtQuick 2.0
 import org.kde.plasma.components 2.0 as Plasma
-import QtQuick.Controls 2.1
+import QtQuick.Controls 2.0
 
 Item {
     width: childrenRect.width + buttonLayout.spacing + 32


### PR DESCRIPTION
修复在Qt 5.7.x 环境中Super+S工作区界面无法显示添加/删除按钮