### PR TITLE
fix: crash when the "width"/"height" value is 0

### DIFF
--- a/scene_opengl.cpp
+++ b/scene_opengl.cpp
@@ -2298,6 +2298,9 @@ void SceneOpenGLShadow::buildQuads()
                        qMax(left.height(), right.height()) +
                        qMax(bottomLeft.height(), bottomRight.height());
 
+    if (width == 0 || height == 0)
+        return;
+
     qreal tx1(0.0), tx2(0.0), ty1(0.0), ty2(0.0);
 
     tx2 = topLeft.width()/width;


### PR DESCRIPTION
https://github.com/linuxdeepin/internal-discussion/issues/1622