### PR TITLE
feat: support use touch screen move/resize window

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -424,6 +424,56 @@ public:
         }
         return true;
     }
+    bool touchDown(quint32 id, const QPointF &pos, quint32 time) override {
+        Q_UNUSED(pos)
+        Q_UNUSED(time)
+
+        AbstractClient *c = workspace()->getMovingClient();
+        // 记录move resize未开始之前的第一次触摸按下
+        if (!c && m_touch_id == UINT_MAX) {
+            m_touch_id = id;
+        }
+
+        return false;
+    }
+    bool touchMotion(quint32 id, const QPointF &pos, quint32 time) override {
+        Q_UNUSED(time)
+
+        if (id != m_touch_id) {
+            return false;
+        }
+
+        AbstractClient *c = workspace()->getMovingClient();
+        if (!c) {
+            return false;
+        }
+
+        c->updateMoveResize(pos);
+
+        return true;
+    }
+    bool touchUp(quint32 id, quint32 time) override {
+        Q_UNUSED(time)
+
+        if (id != m_touch_id) {
+            return false;
+        }
+
+        // 重置touch id
+        m_touch_id = UINT_MAX;
+
+        AbstractClient *c = workspace()->getMovingClient();
+        if (!c) {
+            return false;
+        }
+
+        c->endMoveResize();
+
+        return true;
+    }
+
+private:
+    quint32 m_touch_id = UINT_MAX;
 };
 
 class GlobalShortcutFilter : public InputEventFilter {
@@ -1176,14 +1226,18 @@ void InputRedirection::setupInputFilters()
         installInputEventFilter(new VirtualTerminalFilter);
     }
 #endif
+    MoveResizeFilter *mr_filter = new MoveResizeFilter;
     if (waylandServer()) {
         installInputEventFilter(new TerminateServerFilter);
         installInputEventFilter(new DragAndDropInputFilter);
         installInputEventFilter(new LockScreenFilter);
+    } else {
+        // 非wayland平台时保证move resize事件过滤生效
+        m_firstFilter = mr_filter;
     }
     installInputEventFilter(new ScreenEdgeInputFilter);
     installInputEventFilter(new EffectsFilter);
-    installInputEventFilter(new MoveResizeFilter);
+    installInputEventFilter(mr_filter);
 #ifdef KWIN_BUILD_TABBOX
     installInputEventFilter(new TabBoxInputFilter);
 #endif
@@ -1342,11 +1396,29 @@ void InputRedirection::setupLibInputWithScreens()
 
 void InputRedirection::processPointerMotion(const QPointF &pos, uint32_t time)
 {
+    QMouseEvent event(QEvent::MouseMove, pos, QPointF(), pos, Qt::NoButton,
+                      qApp->mouseButtons(), qApp->queryKeyboardModifiers(),
+                      Qt::MouseEventSynthesizedByApplication);
+
+    if (m_firstFilter && m_firstFilter->pointerEvent(&event, 0)) {
+        return;
+    }
+
     m_pointer->processMotion(pos, time);
 }
 
 void InputRedirection::processPointerButton(uint32_t button, InputRedirection::PointerButtonState state, uint32_t time)
 {
+    const QPointF pos = QCursor::pos();
+    QMouseEvent event(state == PointerButtonReleased ? QEvent::MouseButtonRelease : QEvent::MouseButtonPress,
+                      pos, QPointF(), pos, buttonToQtMouseButton(button),
+                      qApp->mouseButtons(), qApp->queryKeyboardModifiers(),
+                      Qt::MouseEventSynthesizedByApplication);
+
+    if (m_firstFilter && m_firstFilter->pointerEvent(&event, button)) {
+        return;
+    }
+
     m_pointer->processButton(button, state, time);
 }
 
@@ -1372,16 +1444,28 @@ void InputRedirection::processKeymapChange(int fd, uint32_t size)
 
 void InputRedirection::processTouchDown(qint32 id, const QPointF &pos, quint32 time)
 {
+    if (m_firstFilter && m_firstFilter->touchDown(id, pos, time)) {
+        return;
+    }
+
     m_touch->processDown(id, pos, time);
 }
 
 void InputRedirection::processTouchUp(qint32 id, quint32 time)
 {
+    if (m_firstFilter && m_firstFilter->touchUp(id, time)) {
+        return;
+    }
+
     m_touch->processUp(id, time);
 }
 
 void InputRedirection::processTouchMotion(qint32 id, const QPointF &pos, quint32 time)
 {
+    if (m_firstFilter && m_firstFilter->touchMotion(id, pos, time)) {
+        return;
+    }
+
     m_touch->processMotion(id, pos, time);
 }
 

--- a/input.h
+++ b/input.h
@@ -226,6 +226,8 @@ private:
     QVector<InputEventFilter*> m_filters;
     KSharedConfigPtr m_inputConfig;
 
+    InputEventFilter *m_firstFilter = nullptr;
+
     KWIN_SINGLETON(InputRedirection)
     friend InputRedirection *input();
     friend class DecorationEventFilter;

--- a/plugins/platforms/x11/standalone/xinputintegration.cpp
+++ b/plugins/platforms/x11/standalone/xinputintegration.cpp
@@ -39,7 +39,8 @@ class XInputEventFilter : public X11EventFilter
 {
 public:
     XInputEventFilter(int xi_opcode)
-        : X11EventFilter(XCB_GE_GENERIC, xi_opcode, QVector<int>{XI_RawMotion, XI_RawButtonPress, XI_RawButtonRelease, XI_RawKeyPress, XI_RawKeyRelease})
+        : X11EventFilter(XCB_GE_GENERIC, xi_opcode, QVector<int>{XI_RawMotion, XI_RawButtonPress, XI_RawButtonRelease, XI_RawKeyPress, XI_RawKeyRelease,
+                                                                 XI_RawTouchBegin, XI_RawTouchUpdate, XI_RawTouchEnd})
         {}
     virtual ~XInputEventFilter() = default;
 
@@ -82,6 +83,11 @@ public:
                 m_x11Cursor->schedulePoll();
             }
             break;
+        case XI_RawMotion: {
+            auto e = reinterpret_cast<xXIRawEvent*>(event);
+            kwinApp()->platform()->pointerMotion(QCursor::pos(), e->time);
+            break;
+        }
         case XI_RawButtonRelease:
             if (m_xkb) {
                 auto e = reinterpret_cast<xXIRawEvent*>(event);
@@ -110,6 +116,46 @@ public:
                 m_x11Cursor->schedulePoll();
             }
             break;
+        // 在xorg中，一个触摸点的touchUpdate和touchEnd事件只会发送给touchBegin事件的接收者，
+        // 也就是说，当手指已经按在触屏上后，在此之后kwin成功grab了触屏和鼠标事件，但在grab之前
+        // 已经按下的触摸点的后续事件kwin中也无法接收。这样情况发生于：一个client收到touchBegin
+        // 后请求_NET_WM_MOVERESIZE，之后手指移动时无法移动窗口，因此，此处监听原始的触屏事件，
+        // 用于处理此问题。
+        case XI_RawTouchBegin: {
+            auto e = reinterpret_cast<xXIRawEvent*>(event);
+
+            // 鼠标只会跟随第一个触摸点，此处只处理第一个触摸点
+            if (m_first_touch_point  == UINT_MAX) {
+                m_first_touch_point = e->detail;
+            } else {
+                break;
+            }
+
+            kwinApp()->platform()->touchDown(e->detail, QCursor::pos(), e->time);
+            break;
+        }
+        case XI_RawTouchUpdate: {
+            auto e = reinterpret_cast<xXIRawEvent*>(event);
+
+            if (m_first_touch_point != e->detail) {
+                break;
+            }
+
+            kwinApp()->platform()->touchMotion(e->detail, QCursor::pos(), e->time);
+            break;
+        }
+        case XI_RawTouchEnd: {
+            auto e = reinterpret_cast<xXIRawEvent*>(event);
+
+            if (m_first_touch_point != e->detail) {
+                break;
+            }
+
+            // 清除已按下的第一个点
+            m_first_touch_point = UINT_MAX;
+            kwinApp()->platform()->touchUp(e->detail, e->time);
+            break;
+        }
         default:
             if (m_x11Cursor) {
                 m_x11Cursor->schedulePoll();
@@ -130,6 +176,7 @@ private:
     QPointer<X11Cursor> m_x11Cursor;
     // TODO: QPointer
     Xkb *m_xkb = nullptr;
+    quint32 m_first_touch_point = UINT_MAX;
 };
 
 class XKeyPressReleaseEventFilter : public X11EventFilter
@@ -223,10 +270,20 @@ void XInputIntegration::startListening()
     XISetMask(mask1, XI_RawMotion);
     XISetMask(mask1, XI_RawButtonPress);
     XISetMask(mask1, XI_RawButtonRelease);
-    if (m_majorVersion >= 2 && m_minorVersion >= 1) {
-        // we need to listen to all events, which is only available with XInput 2.1
-        XISetMask(mask1, XI_RawKeyPress);
-        XISetMask(mask1, XI_RawKeyRelease);
+
+    if (m_majorVersion >= 2) {
+        if (m_minorVersion >= 1) {
+            // we need to listen to all events, which is only available with XInput 2.1
+            XISetMask(mask1, XI_RawKeyPress);
+            XISetMask(mask1, XI_RawKeyRelease);
+        }
+
+        // 在xinput>=2.2版本时监听触摸事件，支持触摸屏下窗口移动/resize
+        if (m_minorVersion >= 2) {
+            XISetMask(mask1, XI_RawTouchBegin);
+            XISetMask(mask1, XI_RawTouchUpdate);
+            XISetMask(mask1, XI_RawTouchEnd);
+        }
     }
 
     evmasks[0].deviceid = XIAllMasterDevices;

--- a/pointer_input.cpp
+++ b/pointer_input.cpp
@@ -50,7 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace KWin
 {
 
-static Qt::MouseButton buttonToQtMouseButton(uint32_t button)
+Qt::MouseButton buttonToQtMouseButton(uint32_t button)
 {
     switch (button) {
     case BTN_LEFT:

--- a/pointer_input.h
+++ b/pointer_input.h
@@ -40,6 +40,8 @@ class SurfaceInterface;
 namespace KWin
 {
 
+Q_DECL_HIDDEN Qt::MouseButton buttonToQtMouseButton(uint32_t button);
+
 class CursorImage;
 class InputRedirection;
 class Toplevel;


### PR DESCRIPTION
在xorg中，一个触摸点的touchUpdate和touchEnd事件只会发送给touchBegin事件的接收者，
也就是说，当手指已经按在触屏上后，在此之后kwin成功grab了触屏和鼠标事件，但在grab之前
已经按下的触摸点的后续事件kwin中也无法接收。这样情况发生于：一个client收到touchBegin
后请求_NET_WM_MOVERESIZE，之后手指移动时无法移动窗口，因此，此处监听原始的触屏事件，
用于处理此问题。