### PR TITLE
[effects/desktopgrid] Don't display the close button from Present Win…

### DIFF
--- a/effects/desktopgrid/desktopgrid.cpp
+++ b/effects/desktopgrid/desktopgrid.cpp
@@ -1368,8 +1368,31 @@ bool DesktopGridEffect::isActive() const
 
 bool DesktopGridEffect::isRelevantWithPresentWindows(EffectWindow *w) const
 {
-    return !(w->isDesktop() || w->isDock() || w->isSkipSwitcher()) &&
-            w->isCurrentTab() && w->isOnCurrentActivity();
+    if (w->isSpecialWindow() || w->isUtility()) {
+        return false;
+    }
+
+    if (w->isSkipSwitcher()) {
+        return false;
+    }
+
+    if (w->isDeleted()) {
+        return false;
+    }
+
+    if (!w->acceptsFocus()) {
+        return false;
+    }
+
+    if (!w->isCurrentTab()) {
+        return false;
+    }
+
+    if (!w->isOnCurrentActivity()) {
+        return false;
+    }
+
+    return true;
 }
 
 /************************************************


### PR DESCRIPTION
…dows

Summary:
If you activate the Present Windows effect and then the Desktop Grid,
you'll be able to see the close button from PW. The reason for that is
PW doesn't destroy the close button and DG doesn't filter it out.

This patch addesses this problem by syncing DesktopGridEffect::isRelevantWithPresentWindows
with PresentWindowsEffect::isSelectableWindow.

On X11, the close button is filtered by the isSpecialWindow check. On
Wayland, the close button is filtered by the acceptsFocus check.

The proposed solution is kinda hack-ish, but on the other hand, we have
to keep those two methods in sync anyway.

In addition to the close button, notifications won't be displayed too.

BUG: 364710
FIXED-IN: 5.14.3

Test Plan:
* Activate the Present Windows effect;
* Activate the Desktop Grid effect;
* (the close button is no longer visible)

Reviewers: #kwin, graesslin

Reviewed By: #kwin, graesslin

Subscribers: kwin

Tags: #kwin

Differential Revision: https://phabricator.kde.org/D16513