### PR TITLE
fix: always exit showing desktop mode on open windows

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1430,7 +1430,7 @@ void Client::takeFocus()
     }
     workspace()->setShouldGetFocus(this);
 
-    bool breakShowingDesktop = !keepAbove();
+    bool breakShowingDesktop = true;
     if (breakShowingDesktop) {
         foreach (const Client *c, group()->members()) {
             if (c->isDesktop()) {
@@ -1443,9 +1443,16 @@ void Client::takeFocus()
         if (workspace()->showingDesktop()) {
             // 最小化其它所有窗口
             for (Client *c : workspace()->clientList()) {
-                if (this != c && !c->isDock() && !c->isDesktop()) {
-                    c->minimize(true);
+                if (this == c || c->isDock() || c->isDesktop() || skipTaskbar()) {
+                    continue;
                 }
+
+                // 在进入到显示桌面模式后还有活跃的窗口不要最小化，如进入这个模式后才新建的窗口
+                if (c->userTime() > workspace()->showingDesktopTimestamp()) {
+                    continue;
+                }
+
+                c->minimize(true);
             }
 
             workspace()->setShowingDesktop(false);

--- a/workspace.cpp
+++ b/workspace.cpp
@@ -113,6 +113,7 @@ Workspace::Workspace(const QString &sessionKey)
     , force_restacking(false)
     , x_stacking_dirty(true)
     , showing_desktop(false)
+    , showing_desktop_timestamp(-1U)
     , was_user_interaction(false)
     , session_saving(false)
     , block_focus(0)
@@ -1284,6 +1285,8 @@ void Workspace::setShowingDesktop(bool showing)
     const bool changed = showing != showing_desktop;
     rootInfo()->setShowingDesktop(showing);
     showing_desktop = showing;
+    // 记录时间戳，用于判断哪些客户端是在进入到显示桌面模式后新创建的
+    showing_desktop_timestamp = kwinApp()->x11Time();
 
     AbstractClient *topDesk = nullptr;
 

--- a/workspace.h
+++ b/workspace.h
@@ -304,6 +304,7 @@ public:
 
     void setShowingDesktop(bool showing);
     bool showingDesktop() const;
+    xcb_timestamp_t showingDesktopTimestamp() const;
 
     Q_SLOT void setPreviewClientList(const QList<AbstractClient *> &list);
     Q_SLOT bool previewingClientList() const;
@@ -573,6 +574,7 @@ private:
     QList<AbstractClient*> attention_chain;
 
     bool showing_desktop;
+    xcb_timestamp_t showing_desktop_timestamp;
     QList<AbstractClient*> previewClients;
 
     GroupList groups;
@@ -721,6 +723,11 @@ inline bool Workspace::sessionSaving() const
 inline bool Workspace::showingDesktop() const
 {
     return showing_desktop;
+}
+
+inline xcb_timestamp_t Workspace::showingDesktopTimestamp() const
+{
+    return showing_desktop_timestamp;
 }
 
 inline bool Workspace::globalShortcutsDisabled() const


### PR DESCRIPTION
任何新窗口准备获取焦点时都退出显示桌面模式（除Desktop类型外）
且在退出显示桌面模式时不要将跳过任务栏类型的窗口或在进入此模
式之后创建的窗口最小化

https://github.com/linuxdeepin/internal-discussion/issues/1710