### PR TITLE
backends(drm): round refresh rate values from KScreen configs

### DIFF
--- a/plugins/platforms/drm/drm_backend.cpp
+++ b/plugins/platforms/drm/drm_backend.cpp
@@ -44,6 +44,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <libdrm/drm_mode.h>
+#include <math.h>
 
 #ifndef DRM_CAP_CURSOR_WIDTH
 #define DRM_CAP_CURSOR_WIDTH 0x8
@@ -624,7 +625,7 @@ void DrmBackend::installDefaultDisplay()
     dmode.id = 0;
     dmode.size = QSize(mode.hdisplay, mode.vdisplay);
     dmode.flags = KWayland::Server::OutputDeviceInterface::ModeFlag::Current;
-    dmode.refreshRate = mode.vrefresh * 1000LL;
+    dmode.refreshRate = round(mode.vrefresh * 1000LL);
     modes << dmode;
     output->initWaylandOutputDevice(name, model, manufacturer, uuid, modes);
 


### PR DESCRIPTION
Backport https://invent.kde.org/plasma/kwin/-/commit/9f9ad7036518f0d0df984a3eda28e2b4c57607d3
Attempt to resolve https://github.com/linuxdeepin/developer-center/issues/3480

Notice: I did NOT test this PR by myself since I don't have the device to test. Please test the CI package and ensure it actually work before merge!