### PR TITLE
fix: set datasource object is nullptr when datasource is destroyed.

### DIFF
--- a/xwl/dnd.cpp
+++ b/xwl/dnd.cpp
@@ -181,7 +181,6 @@ void Dnd::startDrag()
         return;
     }
     // there can only ever be one Wl native drag at the same time
-    Q_ASSERT(!m_currentDrag);
 
     // new Wl to X drag, init drag and Wl source
     m_currentDrag = new WlToXDrag();


### PR DESCRIPTION
set datasource object is nullptr when datasource is destroyed.