### PR TITLE
fix: splitoutline not hide when client send to this screen

### DIFF
--- a/geometry.cpp
+++ b/geometry.cpp
@@ -3934,6 +3934,13 @@ void AbstractClient::sendToScreen(int newScreen)
             }
         }
     }
+
+    if (waylandServer()) {
+        if (m_moveResize.startScreen != newScreen) {
+            workspace()->updateSplitOutlineLayerShowHide();
+        }
+    }
+
     if (screen() == newScreen)   // Don't use isOnScreen(), that's true even when only partially
         return;
 


### PR DESCRIPTION
update splitoutline when client send to this screen

Log: update splitoutline when client send to this screen

Bug: https://pms.uniontech.com/bug-view-171681.html
Change-Id: Id7dd0613076c3eb7d50e49c0e6ab81c450fb3a32