### PR TITLE
fix: dialog can not get keyboard focus when add mail account

### DIFF
--- a/shell_client.cpp
+++ b/shell_client.cpp
@@ -923,18 +923,22 @@ AbstractClient *ShellClient::findModal(bool allow_itself)
         p = p->transientFor();
     }
 
+    QVector<AbstractClient*> mods;
     QStack<AbstractClient*> stack;
     stack.push(root);
     while (!stack.empty()) {
         auto *cur = stack.top();
         stack.pop();
         if (cur->isModal())
-            return cur;
+            mods.push_back(cur);
         for (auto it = cur->transients().constBegin(); it != cur->transients().constEnd(); ++it)
             stack.push(*it);
     }
 
-    return nullptr;
+    if (mods.count() > 0)
+        return mods.last();
+    else 
+        return nullptr;
 }
 
 bool ShellClient::isCloseable() const


### PR DESCRIPTION
repair dialog can't get input focus when add mail account

Log: repair dialog can't get keyboard focus when add mail account
BugID: https://pms.uniontech.com/bug-view-176683.html
Change-Id: I0d83793f143b77caffbfdced3e607804b7d90a05