### PR TITLE
fix: exit splitScreen when select move in right-click menu

### DIFF
--- a/geometry.cpp
+++ b/geometry.cpp
@@ -18,7 +18,7 @@
 #include "cursor.h"
 #include "netinfo.h"
 #include "workspace.h"
-
+#include "moving_client_x11_filter.h"
 #include "placement.h"
 #include "geometrytip.h"
 #include "rules.h"
@@ -2995,6 +2995,7 @@ void AbstractClient::finishMoveResize(bool cancel)
 
 // FRAME    update();
     emit clientFinishUserMovedResized(this);
+    MovingClientX11Filter::setMoveStatus(false);
 }
 
 void Client::leaveMoveResize()
@@ -3150,7 +3151,7 @@ void AbstractClient::handleMoveResize(const QPoint &local, const QPoint &global)
 {
     const QRect oldGeo = geometry();
     handleMoveResize(local.x(), local.y(), global.x(), global.y());
-    if (!isFullScreen() && isMove()) {
+    if (!isFullScreen() && isMove() && MovingClientX11Filter::getMoveStatus()) {
         if ((quickTileMode() != QuickTileMode(QuickTileFlag::None)) && (oldGeo != geometry() || (workspace()->isDragingWithContent() && m_placeholderWindow.getGeometry() != geometry()))) {
             GeometryUpdatesBlocker blocker(this);
 

--- a/moving_client_x11_filter.cpp
+++ b/moving_client_x11_filter.cpp
@@ -12,10 +12,20 @@
 
 namespace KWin
 {
-
+volatile bool MovingClientX11Filter::isMove = false;
 MovingClientX11Filter::MovingClientX11Filter()
     : X11EventFilter(QVector<int>{XCB_KEY_PRESS, XCB_MOTION_NOTIFY, XCB_BUTTON_PRESS, XCB_BUTTON_RELEASE})
 {
+}
+
+bool MovingClientX11Filter::getMoveStatus()
+{
+    return isMove;
+}
+
+void MovingClientX11Filter::setMoveStatus(const bool &status)
+{
+    isMove = status;
 }
 
 bool MovingClientX11Filter::event(xcb_generic_event_t *event)
@@ -25,6 +35,7 @@ bool MovingClientX11Filter::event(xcb_generic_event_t *event)
         return false;
     }
     auto testWindow = [client, event] (xcb_window_t window) {
+        isMove = true;
         return client->moveResizeGrabWindow() == window && client->windowEvent(event);
     };
 

--- a/moving_client_x11_filter.h
+++ b/moving_client_x11_filter.h
@@ -17,6 +17,9 @@ public:
     explicit MovingClientX11Filter();
 
     bool event(xcb_generic_event_t *event) override;
+    static volatile bool isMove;
+    static bool getMoveStatus();
+    static void setMoveStatus(const bool &status);
 };
 
 }


### PR DESCRIPTION
exit splitScreen when select move in right-click menu

Log: exit splitScreen when select move in right-click menu
Bug: https://pms.uniontech.com/bug-view-175237.html
Change-Id: I5ee875ded43e273a3524705052ef789330c09982