### PR TITLE
Fix: fix the problem that the window cannot be maximized

### DIFF
--- a/abstract_client.h
+++ b/abstract_client.h
@@ -868,6 +868,7 @@ Q_SIGNALS:
     void paletteChanged(const QPalette &p);
     void colorSchemeChanged();
     void captionChanged();
+    void maximizedChanged();
     void clientMaximizedStateChanged(KWin::AbstractClient*, MaximizeMode);
     void clientMaximizedStateChanged(KWin::AbstractClient* c, bool h, bool v);
     void transientChanged();

--- a/pointer_input.cpp
+++ b/pointer_input.cpp
@@ -119,6 +119,7 @@ void PointerInputRedirection::init()
     m_cursor = new CursorImage(this);
     setInited(true);
     InputDeviceHandler::init();
+    connect(workspace(), &Workspace::clientMaximizedChanged, this, &PointerInputRedirection::windowPosChanged);
 
     connect(m_cursor, &CursorImage::changed, kwinApp()->platform(), &Platform::cursorChanged);
     emit m_cursor->changed();
@@ -906,6 +907,12 @@ void PointerInputRedirection::updatePosition(const QPointF &pos)
     }
     m_pos = p;
     emit input()->globalPointerChanged(m_pos);
+}
+
+void PointerInputRedirection::windowPosChanged()
+{
+    auto seat = waylandServer()->seat();
+    emit seat->windowPosChanged();
 }
 
 void PointerInputRedirection::updateButton(uint32_t button, InputRedirection::PointerButtonState state)

--- a/pointer_input.h
+++ b/pointer_input.h
@@ -54,6 +54,7 @@ public:
 
     void init();
     void updatePosition(const QPointF &pos);
+    void windowPosChanged();
 
     void updateAfterScreenChange();
     bool supportsWarping() const;

--- a/shell_client.cpp
+++ b/shell_client.cpp
@@ -2021,6 +2021,7 @@ void ShellClient::updateMaximizeMode(MaximizeMode maximizeMode)
 
     emit clientMaximizedStateChanged(this, m_maximizeMode);
     emit clientMaximizedStateChanged(this, m_maximizeMode & MaximizeHorizontal, m_maximizeMode & MaximizeVertical);
+    emit maximizedChanged();
 }
 
 bool ShellClient::hasStrut() const

--- a/workspace.cpp
+++ b/workspace.cpp
@@ -663,6 +663,7 @@ void Workspace::setupClientConnections(AbstractClient *c)
     connect(c, &Toplevel::needsRepaint, m_compositor, &Compositor::scheduleRepaint);
     connect(c, &AbstractClient::desktopPresenceChanged, this, &Workspace::desktopPresenceChanged);
     connect(c, &AbstractClient::minimizedChanged, this, std::bind(&Workspace::clientMinimizedChanged, this, c));
+    connect(c, &AbstractClient::maximizedChanged, this, std::bind(&Workspace::clientMaximizedChanged, this, c));
 }
 
 Client* Workspace::createClient(xcb_window_t w, bool is_mapped)

--- a/workspace.h
+++ b/workspace.h
@@ -611,6 +611,7 @@ Q_SIGNALS:
     void clientActivated(KWin::AbstractClient*);
     void clientDemandsAttentionChanged(KWin::AbstractClient*, bool);
     void clientMinimizedChanged(KWin::AbstractClient*);
+    void clientMaximizedChanged(KWin::AbstractClient*);
     void groupAdded(KWin::Group*);
     void unmanagedAdded(KWin::Unmanaged*);
     void unmanagedRemoved(KWin::Unmanaged*);


### PR DESCRIPTION
Need to resend the mouse position to the application when the window changed.
When switching from the maximized to the right split screen and again, the mouse position does not change, only the press event is reported. Since the window has changed, the relative coordinates are invalid and no response is made.

Log: fix the problem that the window cannot be maximized Task: https://pms.uniontech.com/zentao/bug-view-122483.html

Change-Id: I274c8b951e490fcb8c860d07845f4a568b2c39b1
Signed-off-by: ut004146 <zhangqiyi@uniontech.com>
Signed-off-by: zhang qiyi <zhangqiyi@uniontech.com>