### PR TITLE
fix: only in X11 exit splitScreen when select move in right-click menu

### DIFF
--- a/geometry.cpp
+++ b/geometry.cpp
@@ -3151,7 +3151,10 @@ void AbstractClient::handleMoveResize(const QPoint &local, const QPoint &global)
 {
     const QRect oldGeo = geometry();
     handleMoveResize(local.x(), local.y(), global.x(), global.y());
-    if (!isFullScreen() && isMove() && MovingClientX11Filter::getMoveStatus()) {
+    if (!isFullScreen() && isMove()) {
+        if (!waylandServer() && !MovingClientX11Filter::getMoveStatus()) 
+            return;
+
         if ((quickTileMode() != QuickTileMode(QuickTileFlag::None)) && (oldGeo != geometry() || (workspace()->isDragingWithContent() && m_placeholderWindow.getGeometry() != geometry()))) {
             GeometryUpdatesBlocker blocker(this);
 


### PR DESCRIPTION
only in X11 exit splitScreen when select move in right-click menu

Log: only in X11 exit splitScreen when select move in right-click menu

Bug: https://pms.uniontech.com/bug-view-175237.html