### PR TITLE
fix: splitoutline apper after touchpad splitscreen

### DIFF
--- a/geometry.cpp
+++ b/geometry.cpp
@@ -78,6 +78,7 @@ void Workspace::desktopResized()
         if (splitapp_stacking_order.size()) {
             QTimer::singleShot(400, [&]() {
                 workspace()->updateSplitOutlineState(1, VirtualDesktopManager::self()->current(), true);
+                clearSplitOutline();
             });
             splitapp_stacking_order.clear();
         }
@@ -386,6 +387,7 @@ void Workspace::updateClientArea(bool force)
 
         QTimer::singleShot(400, [&]() {
             workspace()->updateSplitOutlineState(1, VirtualDesktopManager::self()->current(), true);
+            clearSplitOutline();
         });
 
         oldrestrictedmovearea.clear(); // reset, no longer valid or needed

--- a/placement.cpp
+++ b/placement.cpp
@@ -820,6 +820,11 @@ void Workspace::quickTileWindow(QuickTileMode mode)
     if (!active_client->checkClientAllowToTile()) {
         return;
     }
+
+    auto t = active_client->quickTileMode();
+    if (t == QuickTileMode(QuickTileFlag::Left) || t == QuickTileMode(QuickTileFlag::Right)) {
+        active_client->cancelSplitOutline();
+    }
     active_client->setQuickTileMode(mode, true);
 
     active_client->handlequickTileModeChanged();

--- a/shell_client.cpp
+++ b/shell_client.cpp
@@ -2388,6 +2388,7 @@ void ShellClient::doMinimize()
 {
     if (isMinimized()) {
         cancelSplitOutline();
+        workspace()->updateSplitOutlineLayerShowHide();
         workspace()->clientHidden(this);
     } else {
         handlequickTileModeChanged();

--- a/workspace.cpp
+++ b/workspace.cpp
@@ -373,6 +373,9 @@ void Workspace::init()
                     c->setShortcut(QString());   // Remove from client_keys
                 }
                 clientHidden(c);
+                if (m_lastSplitClient == c) {
+                    m_lastSplitClient = nullptr;
+                }
                 emit clientRemoved(c);
                 markXStackingOrderAsDirty();
                 updateStackingOrder(true);
@@ -800,6 +803,10 @@ void Workspace::removeClient(Client* c)
         last_active_client = 0;
     if (c == delayfocus_client)
         cancelDelayFocus();
+
+    if (m_lastSplitClient == c) {
+        m_lastSplitClient = nullptr;
+    }
 
     emit clientRemoved(c);
     updateStackingOrder(true);


### PR DESCRIPTION
cancel splitoutline before touchpad splitscreen

Log: cancel splitoutline before touchpad splitscreen

Bug: https://pms.uniontech.com/bug-view-175305.html
Change-Id: I997714c9c3c1f7e6b8fc3cd762a251be39409e87