### PR TITLE
fix: Update screen lock position when screen has been changed

### DIFF
--- a/shell_client.cpp
+++ b/shell_client.cpp
@@ -189,7 +189,7 @@ void ShellClient::initSurface(T *shellSurface)
     connect(shellSurface, &T::transientForChanged, this, &ShellClient::setTransient);
 
     connect(this, &ShellClient::geometryChanged, this, &ShellClient::updateClientOutputs);
-    connect(screens(), &Screens::changed, this, &ShellClient::updateClientOutputs,
+    connect(screens(), &Screens::changed, this, &ShellClient::handleScreenChanged,
             Qt::QueuedConnection);
     connect(screens(), &Screens::outputResourceChanged, this, &ShellClient::updateClientOutputs,
             Qt::QueuedConnection);
@@ -2470,6 +2470,18 @@ void ShellClient::popupDone()
     if (m_xdgShellPopup) {
         m_xdgShellPopup->popupDone();
     }
+}
+
+void ShellClient::handleScreenChanged()
+{
+    QRect screenarea = workspace()->clientArea(ScreenArea, this);
+    if (isOnScreenDisplay() && !screenarea.intersects(geometry())) {
+        QRect rect = QRect(screenarea.topLeft(), geometry().size());
+        if (rect.isValid()) {
+            doSetGeometry(rect);
+        }
+    }
+    updateClientOutputs();
 }
 
 void ShellClient::updateClientOutputs()

--- a/shell_client.h
+++ b/shell_client.h
@@ -286,6 +286,7 @@ private:
     void markAsMapped();
     void setTransient();
     bool shouldExposeToWindowManagement();
+    void handleScreenChanged();
     void updateClientOutputs();
     KWayland::Server::XdgShellSurfaceInterface::States xdgSurfaceStates() const;
     void updateShowOnScreenEdge();


### PR DESCRIPTION
The screen had been changed, the window position is outof the
screen, should uUpdate screen lock position immediately.

Log: Update screen lock position when screen has been changed
Bug: https://pms.uniontech.com/bug-view-163333.html

Signed-off-by: Chaojiang Luo <luochaojiang@uniontech.com>