### PR TITLE
feat: support Multi-GPU

### DIFF
--- a/plugins/platforms/drm/CMakeLists.txt
+++ b/plugins/platforms/drm/CMakeLists.txt
@@ -7,6 +7,7 @@ set(DRM_SOURCES
     drm_output.cpp
     drm_buffer.cpp
     drm_inputeventfilter.cpp
+    drm_gpu.cpp
     logging.cpp
     scene_qpainter_drm_backend.cpp
     screens_drm.cpp
@@ -21,6 +22,8 @@ if(HAVE_GBM)
         gbm_dmabuf.cpp
     )
 endif()
+
+add_definitions(-DHAVE_EGL_STREAMS=0)
 
 include_directories(${CMAKE_SOURCE_DIR}/platformsupport/scenes/opengl)
 

--- a/plugins/platforms/drm/drm_backend.cpp
+++ b/plugins/platforms/drm/drm_backend.cpp
@@ -20,10 +20,13 @@
 #include "screens_drm.h"
 #include "udev.h"
 #include "wayland_server.h"
-#include "log.h"
 #if HAVE_GBM
+#include "egl_gbm_backend.h"
 #include <gbm.h>
 #include "gbm_dmabuf.h"
+#endif
+#if HAVE_EGL_STREAMS
+#include "egl_stream_backend.h"
 #endif
 // KWayland
 #include <KWayland/Server/seat_interface.h>
@@ -44,7 +47,8 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <libdrm/drm_mode.h>
-#include <chrono>
+
+#include "drm_gpu.h"
 
 #ifndef DRM_CAP_CURSOR_WIDTH
 #define DRM_CAP_CURSOR_WIDTH 0x8
@@ -56,15 +60,8 @@
 
 #define KWIN_DRM_EVENT_CONTEXT_VERSION 2
 
-#include <sys/sdt.h>
-
 namespace KWin
 {
-
-int drmIsMaster(int fd)
-{
-    return drmAuthMagic(fd, 0) != -EACCES;
-}
 
 DrmBackend::DrmBackend(QObject *parent)
     : Platform(parent)
@@ -72,31 +69,23 @@ DrmBackend::DrmBackend(QObject *parent)
     , m_udevMonitor(m_udev->monitor())
     , m_dpmsFilter()
 {
+#if HAVE_EGL_STREAMS
+    if (qEnvironmentVariableIsSet("KWIN_DRM_USE_EGL_STREAMS")) {
+        m_useEglStreams = true;
+    }
+#endif
     setSupportsGammaControl(true);
     handleOutputs();
 }
 
 DrmBackend::~DrmBackend()
 {
-#if HAVE_GBM
-    if (m_gbmDevice) {
-        gbm_device_destroy(m_gbmDevice);
-    }
-#endif
-    if (m_fd >= 0) {
+    if (m_gpus.size() > 0) {
         // wait for pageflips
         while (m_pageFlipsPending != 0) {
             QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents);
         }
-        // we need to first remove all outputs
-        qDeleteAll(m_outputs);
-        m_outputs.clear();
-        m_enabledOutputs.clear();
-
-        qDeleteAll(m_planes);
-        qDeleteAll(m_crtcs);
-        qDeleteAll(m_connectors);
-        close(m_fd);
+        qDeleteAll(m_gpus);
     }
 }
 
@@ -164,16 +153,6 @@ void DrmBackend::checkOutputsAreOn()
 
 void DrmBackend::activate(bool active)
 {
-    static std::chrono::time_point<std::chrono::steady_clock> st0 = std::chrono::steady_clock::now();
-    auto st1 = std::chrono::steady_clock::now();
-    if (m_enabledOutputs.count() > 1) {
-        if (m_enabledOutputs[0]->geometry() == m_enabledOutputs[1]->geometry()) {
-            if (1000 > std::chrono::duration_cast<std::chrono::milliseconds>(st1 - st0).count())
-                return;
-        }
-    }
-    st0 = st1;
-
     if (active) {
         qCDebug(KWIN_DRM) << "Activating session.";
         reactivate();
@@ -204,9 +183,6 @@ void DrmBackend::reactivate()
                 }
             }
         }
-    }
-    for (auto it = m_enabledOutputs.constBegin(); it != m_enabledOutputs.constEnd(); ++it) {
-        (*it)->m_modesetRequested = true;
     }
     // restart compositor
     m_pageFlipsPending = 0;
@@ -257,133 +233,126 @@ void DrmBackend::pageFlipHandler(int fd, unsigned int frame, unsigned int sec, u
     }
 }
 
+DrmGpu *DrmBackend::addGpu(UdevDevice *device)
+{
+    auto devNode = QByteArray(device->devNode());
+    int fd = LogindIntegration::self()->takeDevice(devNode.constData());
+    if (fd < 0) {
+        qCWarning(KWIN_DRM) << "failed to open drm device at" << devNode;
+        return nullptr;
+    } else {
+        qCInfo(KWIN_DRM) << "finished to open drm device at" << devNode;
+    }
+    m_active = true;
+    QSocketNotifier *notifier = new QSocketNotifier(fd, QSocketNotifier::Read, this);
+    connect(notifier, &QSocketNotifier::activated, this, [fd] {
+        if (!LogindIntegration::self()->isActiveSession()) {
+            return;
+        }
+        drmEventContext e;
+        memset(&e, 0, sizeof e);
+        e.version = KWIN_DRM_EVENT_CONTEXT_VERSION;
+        e.page_flip_handler = pageFlipHandler;
+        drmHandleEvent(fd, &e);
+    });
+    DrmGpu *gpu = new DrmGpu(this, devNode, fd, device->sysNum());
+    connect(gpu, &DrmGpu::outputAdded, this, &DrmBackend::addOutput);
+    connect(gpu, &DrmGpu::outputRemoved, this, &DrmBackend::removeOutput);
+    m_gpus.append(gpu);
+
+    if (!m_eglGbmBackend)
+        createOpenGLBackend();
+    Q_ASSERT(m_eglGbmBackend);
+    m_eglGbmBackend->connectToGpu(gpu);
+
+    return gpu;
+}
+
 void DrmBackend::openDrm()
 {
     connect(LogindIntegration::self(), &LogindIntegration::sessionActiveChanged, this, &DrmBackend::activate);
-    UdevDevice::Ptr device = m_udev->primaryGpu();
-    if (!device) {
+    std::vector<UdevDevice::Ptr> devices = m_udev->listGPUs();
+    if (devices.size() == 0) {
         qCWarning(KWIN_DRM) << "Did not find a GPU";
         return;
+    } else {
+        qCInfo(KWIN_DRM) << "Found" << devices.size() << "GPUs";
     }
-    int fd = LogindIntegration::self()->takeDevice(device->devNode());
-    if (fd < 0) {
-        qCWarning(KWIN_DRM) << "failed to open drm device at" << device->devNode();
-        return;
-    }
-    m_fd = fd;
-    m_active = true;
-    QSocketNotifier *notifier = new QSocketNotifier(m_fd, QSocketNotifier::Read, this);
-    connect(notifier, &QSocketNotifier::activated, this,
-        [this] {
-            if (!LogindIntegration::self()->isActiveSession()) {
-                return;
-            }
-            drmEventContext e;
-            memset(&e, 0, sizeof e);
-            e.version = KWIN_DRM_EVENT_CONTEXT_VERSION;
-            e.page_flip_handler = pageFlipHandler;
-            drmHandleEvent(m_fd, &e);
-        }
-    );
-    m_drmId = device->sysNum();
 
+    for (unsigned int gpu_index = 0; gpu_index < devices.size(); gpu_index++) {
+        auto device = std::move(devices.at(gpu_index));
+        addGpu(device.get());
+    }
+    
     // trying to activate Atomic Mode Setting (this means also Universal Planes)
     if (!qEnvironmentVariableIsSet("KWIN_DRM_NO_AMS")) {
-        if (drmSetClientCap(m_fd, DRM_CLIENT_CAP_ATOMIC, 1) == 0) {
-            qCDebug(KWIN_DRM) << "Using Atomic Mode Setting.";
-            m_atomicModeSetting = true;
-
-            ScopedDrmPointer<drmModePlaneRes, &drmModeFreePlaneResources> planeResources(drmModeGetPlaneResources(m_fd));
-            if (!planeResources) {
-                qCWarning(KWIN_DRM) << "Failed to get plane resources. Falling back to legacy mode";
-                m_atomicModeSetting = false;
-            }
-
-            if (m_atomicModeSetting) {
-                qCDebug(KWIN_DRM) << "Number of planes:" << planeResources->count_planes;
-
-                // create the plane objects
-                for (unsigned int i = 0; i < planeResources->count_planes; ++i) {
-                    drmModePlane *kplane = drmModeGetPlane(m_fd, planeResources->planes[i]);
-                    DrmPlane *p = new DrmPlane(kplane->plane_id, m_fd);
-                    if (p->atomicInit()) {
-                        m_planes << p;
-                        if (p->type() == DrmPlane::TypeIndex::Overlay) {
-                            m_overlayPlanes << p;
-                        }
-                    } else {
-                        delete p;
-                    }
-                }
-
-                if (m_planes.isEmpty()) {
-                    qCWarning(KWIN_DRM) << "Failed to create any plane. Falling back to legacy mode";
-                    m_atomicModeSetting = false;
-                }
-            }
-        } else {
-            qCWarning(KWIN_DRM) << "drmSetClientCap for Atomic Mode Setting failed. Using legacy mode.";
-        }
-    }
-
-    ScopedDrmPointer<_drmModeRes, &drmModeFreeResources> resources(drmModeGetResources(m_fd));
-    drmModeRes *res = resources.data();
-    if (!resources) {
-        qCWarning(KWIN_DRM) << "drmModeGetResources failed";
-        DLOGC("Drm get resources failed!FD[%d]", m_fd);
-        return;
-    }
-
-    for (int i = 0; i < res->count_connectors; ++i) {
-        DLOGD("Get connector!ID[%d],Index[%d]", res->connectors[i], i);
-        m_connectors << new DrmConnector(res->connectors[i], m_fd);
-    }
-    for (int i = 0; i < res->count_crtcs; ++i) {
-        DLOGD("Get Crtcs!ID[%d],Index[%d]", res->crtcs[i], i);
-        m_crtcs << new DrmCrtc(res->crtcs[i], this, i);
-    }
-
-    if (m_atomicModeSetting) {
-        auto tryAtomicInit = [] (DrmObject *obj) -> bool {
-            if (obj->atomicInit()) {
-                return false;
-            } else {
-                delete obj;
-                return true;
-            }
-        };
-        m_connectors.erase(std::remove_if(m_connectors.begin(), m_connectors.end(), tryAtomicInit), m_connectors.end());
-        m_crtcs.erase(std::remove_if(m_crtcs.begin(), m_crtcs.end(), tryAtomicInit), m_crtcs.end());
+        for (auto gpu : m_gpus)
+            gpu->tryAMS();
     }
 
     initCursor();
-    updateOutputs();
+    if (!updateOutputs())
+        return;
 
     if (m_outputs.isEmpty()) {
         qCDebug(KWIN_DRM) << "No connected outputs found on startup.";
-        DLOGC("No connected outputs found on startup!");
     }
-
+    
     // setup udevMonitor
     if (m_udevMonitor) {
         m_udevMonitor->filterSubsystemDevType("drm");
         const int fd = m_udevMonitor->fd();
         if (fd != -1) {
             QSocketNotifier *notifier = new QSocketNotifier(fd, QSocketNotifier::Read, this);
-            connect(notifier, &QSocketNotifier::activated, this,
-                [this] {
+            connect(notifier, &QSocketNotifier::activated, this, [this] {
                     auto device = m_udevMonitor->getDevice();
                     if (!device) {
                         return;
                     }
-                    if (device->sysNum() != m_drmId) {
+                    bool drm = false;
+                    for (auto gpu : m_gpus) {
+                        if (gpu->drmId() == device->sysNum()) {
+                            drm = true;
+                            break;
+                        }
+                    }
+                    if (!drm && !QByteArray(device->devNode()).startsWith("/dev/dri/card")) {
                         return;
                     }
-                    if (device->hasProperty("HOTPLUG", "1")) {
-                        qCDebug(KWIN_DRM) << "Received hot plug event for monitored drm device";
-                        DLOGD("Received hot plug event for %s!", device->devNode());
-                        updateOutputs();
-                        updateCursor();
+
+                    if (device->action() == "add") {
+                        qCDebug(KWIN_DRM) << "Received hot plug GPU add event:" << device->devNode();
+                        if (auto gpu = addGpu(device.get())) {
+                            if (!qEnvironmentVariableIsSet("KWIN_DRM_NO_AMS")) {
+                                gpu->tryAMS();
+                            }
+                            updateOutputs();
+                            updateCursor();
+                        }
+                    } else if (device->action() == "remove") {
+                        DrmGpu *gpu = findGpu(device->sysNum());
+                        if (gpu) {
+                           if (primaryGpu() == gpu) {
+                               qCCritical(KWIN_DRM) << "Primary gpu has been removed! Quitting...";
+                               QCoreApplication::exit(1);
+                               return;
+                           } else {
+		              gpu->handleGPURemove();
+                              m_gpus.removeAll(gpu);
+                              updateOutputs();
+                                updateCursor();
+                           }
+                        }
+                    } else if (device->action() == "change") {
+                        DrmGpu *gpu = findGpu(device->sysNum());
+                        if (!gpu) {
+                            gpu = addGpu(device.get());
+                        }
+                        if (gpu) {
+                            qCDebug(KWIN_DRM) << "Received change event for monitored drm device" << gpu->devNode();
+                            updateOutputs();
+                            updateCursor();
+                        }
                     }
                 }
             );
@@ -393,276 +362,45 @@ void DrmBackend::openDrm()
     setReady(true);
 }
 
-void DrmBackend::updateOutputs()
+void DrmBackend::addOutput(DrmOutput *o)
 {
-    if (m_fd < 0) {
-        DLOGC("Drm fd error!");
-        return;
+    m_outputs.append(o);
+    m_enabledOutputs.append(o);
+    emit o->gpu()->outputEnabled(o);
+}
+
+void DrmBackend::removeOutput(DrmOutput *o)
+{
+    emit o->gpu()->outputDisabled(o);
+    m_outputs.removeOne(o);
+    m_enabledOutputs.removeOne(o);
+}
+
+bool DrmBackend::updateOutputs()
+{
+    if (m_gpus.size() == 0) {
+        return false;
     }
-
-    ScopedDrmPointer<_drmModeRes, &drmModeFreeResources> resources(drmModeGetResources(m_fd));
-    if (!resources) {
-        qCWarning(KWIN_DRM) << "drmModeGetResources failed";
-        DLOGC("Drm get resources failed!FD[%d]", m_fd);
-        return;
-    }
-
-    QVector<DrmOutput*> connectedOutputs;
-    QVector<DrmConnector*> pendingConnectors;
-
-    bool outputChanged = false;
-
-    // split up connected connectors in already or not yet assigned ones
-    for (DrmConnector *con : qAsConst(m_connectors)) {
-        if (!con->isConnected()) {
-            DLOGC("Connector is not connected!ID[%d]", con->id());
-            continue;
-        }
-
-        if (DrmOutput *o = findOutput(con->id())) {
-            DLOGD("Connector is reconnected!ID[%d]", con->id());
-            connectedOutputs << o;
-        } else {
-            DLOGD("New Connector is connected!ID[%d]", con->id());
-            pendingConnectors << con;
-            outputChanged = true;
-        }
-    }
-
-    // check for outputs which got removed
-    auto it = m_outputs.begin();
-    while (it != m_outputs.end()) {
-        if (connectedOutputs.contains(*it)) {
-            it++;
-            continue;
-        }
-        DrmOutput *removed = *it;
-
-        // handle it later
-        if (removed == m_defaultOutput) {
-            it++;
-            continue;
-        }
-
-        outputChanged = true;
-
-        it = m_outputs.erase(it);
-        m_enabledOutputs.removeOne(removed);
-        emit outputRemoved(removed);
-        qCDebug(KWIN_DRM) << "request output teardown from hotplug event" << removed->name() << removed->uuid();
-        DLOGD("Request output[%s:%x] teardown from hotplug event!", removed->name().toLocal8Bit().data(), removed->uuid().data());
-        removed->teardown();
-    }
-
-    if (m_disableMultiScreens && !connectedOutputs.isEmpty()) {
-        DLOGD("skip updateOutputs for disableMultiScreens, already has connected screen");
-        return;
-    }
-
-    // now check new connections
-    for (DrmConnector *con : qAsConst(pendingConnectors)) {
-        ScopedDrmPointer<_drmModeConnector, &drmModeFreeConnector> connector(drmModeGetConnector(m_fd, con->id()));
-        if (!connector) {
-            DLOGC("Can't find connector!");
-            continue;
-        }
-        if (connector->count_modes == 0) {
-            DLOGC("Connector's mode count is 0!");
-            continue;
-        }
-        bool outputDone = false;
-
-        QVector<uint32_t> encoders = con->encoders();
-        for (auto encId : qAsConst(encoders)) {
-            ScopedDrmPointer<_drmModeEncoder, &drmModeFreeEncoder> encoder(drmModeGetEncoder(m_fd, encId));
-            if (!encoder) {
-                DLOGC("Get encoder error!");
-                continue;
-            }
-            for (DrmCrtc *crtc : qAsConst(m_crtcs)) {
-                if (!(encoder->possible_crtcs & (1 << crtc->resIndex()))) {
-                    DLOGC("No this crtc.ID[%d],Index[%d],Bitmask of possible CRTCs[%d]!", crtc->id(), crtc->resIndex(), encoder->possible_crtcs);
-                    continue;
-                }
-
-                // check if crtc isn't used yet -- currently we don't allow multiple outputs on one crtc (cloned mode)
-                auto it = std::find_if(connectedOutputs.constBegin(), connectedOutputs.constEnd(),
-                    [crtc] (DrmOutput *o) {
-                        return o->m_crtc == crtc;
-                    }
-                );
-                if (it != connectedOutputs.constEnd()) {
-                    continue;
-                }
-
-                // we found a suitable encoder+crtc
-                // TODO: we could avoid these lib drm calls if we store all struct data in DrmCrtc and DrmConnector in the beginning
-                ScopedDrmPointer<_drmModeCrtc, &drmModeFreeCrtc> modeCrtc(drmModeGetCrtc(m_fd, crtc->id()));
-                if (!modeCrtc) {
-                    DLOGC("Get crtc[%d] error!", crtc->id());
-                    continue;
-                }
-
-                DrmOutput *output = new DrmOutput(this);
-                con->setOutput(output);
-                output->m_conn = con;
-                crtc->setOutput(output);
-                output->m_crtc = crtc;
-                connect(output, &DrmOutput::dpmsChanged, this, &DrmBackend::outputDpmsChanged);
-
-                if (connector) {
-                    DLOGD("Use connector mode");
-                    output->m_mode = connector->modes[0];
-                } else if (modeCrtc->mode_valid) {
-                    DLOGD("Use crtc mode");
-                    output->m_mode = modeCrtc->mode;
-                }
-                qCDebug(KWIN_DRM) << "For new output use mode " << output->m_mode.name << output->name() \
-                                  << "connector mode" << connector->modes[0].name \
-                                  << "crtc mode" << modeCrtc->mode.name;
-                DLOGD("Output[%s] mode[%s]", output->name().toLocal8Bit().data(), output->m_mode.name);
-
-                if (!output->init(connector.data())) {
-                    qCWarning(KWIN_DRM) << "Failed to create output for connector " << con->id();
-                    DLOGC("Failed to create output for connector[%d].", con->id());
-                    delete output;
-                    continue;
-                }
-                if (!output->initCursor(m_cursorSize)) {
-                    DLOGD("Use software cursor.");
-                    qCDebug(KWIN_DRM) << "Use software cursor.";
-                    setSoftWareCursor(true);
-                }
-                qCDebug(KWIN_DRM) << "Found new output with uuid" << output->uuid();
-                DLOGD("Found new output with uuid[%s]", output->uuid().data());
-
-                connectedOutputs << output;
-                m_enabledOutputs << output;
-                emit outputAdded(output);
-                outputDone = true;
-                break;
-            }
-            if (outputDone) {
-                break;
-            }
-        }
-        if (m_disableMultiScreens && !connectedOutputs.isEmpty()) {
-            DLOGD("skip for disableMultiScreens, already has pending Connector");
-            break;
-        }
-    }
-    std::sort(connectedOutputs.begin(), connectedOutputs.end(), [] (DrmOutput *a, DrmOutput *b) { return a->m_conn->id() < b->m_conn->id(); });
-
-    if (!outputChanged) {
-        qCDebug(KWIN_DRM) << "Not output chenged, stop update outputs";
-        return;
-    }
-
-    m_outputs = connectedOutputs;
-
-    if (!m_outputs.isEmpty() && m_defaultOutput && m_defaultOutput->isEnabled()) {
-        m_defaultOutput->waylandOutputDevice()->setEnabled(KWayland::Server::OutputDeviceInterface::Enablement::Disabled);
-        m_defaultOutput->waylandOutputDevice()->destroy();
-        m_defaultOutput->waylandOutput()->destroy();
-        m_enabledOutputs.removeOne(m_defaultOutput);
-        emit outputRemoved(m_defaultOutput);
-    }
-
-    if (m_outputs.size() == 1 && m_enabledOutputs.isEmpty()) {
-        auto* output = m_outputs.first();
-        output->setEnabled(true);
+    const auto oldOutputs = m_outputs;
+    for (auto gpu : m_gpus)
+        gpu->updateOutputs();
+    
+    if (!oldOutputs.isEmpty()) {
+        std::sort(m_outputs.begin(), m_outputs.end(), [&] (DrmOutput *a, DrmOutput *b) {
+            const int aIndex = oldOutputs.indexOf(a);
+            const int bIndex = oldOutputs.indexOf(b);
+            if (aIndex == bIndex)
+                return a->m_conn->id() > b->m_conn->id();
+            return bIndex < 0 || (aIndex >= 0 && aIndex < bIndex);
+        });
     }
 
     readOutputsConfiguration();
-    outputDpmsChanged();
-
+    updateOutputsEnabled();
     if (!m_outputs.isEmpty()) {
-        qDebug() << "emit screensQueried";
         emit screensQueried();
-    } else if (!m_defaultOutput) {
-        QTimer::singleShot(100, this, [=] { emit startWithoutScreen(); });
     }
-}
-
-void DrmBackend::disableMultiScreens()
-{
-    m_disableMultiScreens = true;
-}
-
-void DrmBackend::installDefaultDisplay()
-{
-    for (DrmConnector *con : qAsConst(m_connectors)) {
-        if (con->isConnected()) {
-            DLOGD("Already received physical display, will not create virtual display");
-            return;
-        }
-    }
-    DLOGD("There is no physical display, install virtual display for system");
-    DrmOutput *output = new DrmOutput(this);
-    output->m_isVirtual = true;
-
-    drmModeModeInfo mode;
-    strcpy(mode.name, "1920x1080");
-    mode.clock = 148500;
-    mode.hdisplay = 1920;
-    mode.hsync_start = 2008;
-    mode.hsync_end = 2052;
-    mode.htotal = 2200;
-    mode.hskew = 0;
-
-    mode.vdisplay = 1080;
-    mode.vsync_start = 1084;
-    mode.vsync_end = 1089;
-    mode.vtotal = 1125,
-    mode.vscan = 0;
-
-    mode.vrefresh = 60;
-
-    mode.flags = 5;
-    mode.type = 72;
-
-    //connector_id  48   47   1   1   530   300   15   5
-
-    //1.Add mode info
-    output->m_mode = mode;
-
-    output->setRawPhysicalSize(QSize(0, 0));
-
-    //2.init wayland output device
-    QString name = "VGA-1";
-    QString model = "VGA-1000-unknown";
-    QString manufacturer = "UOS";
-    QByteArray uuid = "ffffffffff";
-    QVector<KWayland::Server::OutputDeviceInterface::Mode> modes;
-    KWayland::Server::OutputDeviceInterface::Mode dmode;
-    dmode.id = 0;
-    dmode.size = QSize(mode.hdisplay, mode.vdisplay);
-    dmode.flags = KWayland::Server::OutputDeviceInterface::ModeFlag::Current;
-    dmode.refreshRate = mode.vrefresh * 1000LL;
-    modes << dmode;
-    output->initWaylandOutputDevice(name, model, manufacturer, uuid, modes);
-
-    //3.set enable
-    output->setEnabled(true);
-
-    //4.set position and scale
-    QPoint pos(0, 0);
-    output->setGlobalPos(pos);
-    output->setScale(1.0);
-
-    //5.set wayland mode
-    output->setWaylandMode();
-
-    m_defaultOutput = output;
-
-    m_outputs << output;
-    m_enabledOutputs << output;
-    emit outputAdded(output);
-
-    setOutputsEnabled(true);
-    setSoftWareCursor(true);
-
-    emit screensQueried();
+    return true;
 }
 
 void DrmBackend::readOutputsConfiguration()
@@ -676,18 +414,28 @@ void DrmBackend::readOutputsConfiguration()
     // default position goes from left to right
     QPoint pos(0, 0);
     for (auto it = m_outputs.begin(); it != m_outputs.end(); ++it) {
+        qCDebug(KWIN_DRM) << "Reading output configuration for [" << uuid << "] ["<< (*it)->uuid() << "]";
         const auto outputConfig = configGroup.group((*it)->uuid());
-        if ((*it)->hasSetGlobalPosition()) {
-            pos = (*it)->globalPos();
-        }
-        qCDebug(KWIN_DRM) << "Reading output configuration for [" << uuid << "] ["<< (*it)->uuid() << "]"
-            << outputConfig.readEntry<QPoint>("Position", pos);
         (*it)->setGlobalPos(outputConfig.readEntry<QPoint>("Position", pos));
         // TODO: add mode
-        (*it)->setScale(outputConfig.readEntry("Scale", 1.0));
-        if ((*it)->isEnabled()) {
-            pos.setX(pos.x() + (*it)->geometry().width());
-        }
+        if (outputConfig.hasKey("Scale"))
+            (*it)->setScale(outputConfig.readEntry("Scale", 1.0));
+        pos.setX(pos.x() + (*it)->geometry().width());
+    }
+}
+
+void DrmBackend::writeOutputsConfiguration()
+{
+    if (m_outputs.isEmpty()) {
+        return;
+    }
+    const QByteArray uuid = generateOutputConfigurationUuid();
+    auto configGroup = KSharedConfig::openConfig()->group("DrmOutputs").group(uuid);
+    // default position goes from left to right
+    for (auto it = m_outputs.cbegin(); it != m_outputs.cend(); ++it) {
+        qCDebug(KWIN_DRM) << "Writing output configuration for [" << uuid << "] ["<< (*it)->uuid() << "]";
+        auto outputConfig = configGroup.group((*it)->uuid());
+        outputConfig.writeEntry("Scale", (*it)->scale());
     }
 }
 
@@ -707,26 +455,227 @@ QByteArray DrmBackend::generateOutputConfigurationUuid() const
 
 void DrmBackend::enableOutput(DrmOutput *output, bool enable)
 {
-    qDebug() << "output" << output->uuid() << output->geometry() << output->globalPos() << enable;
     if (enable) {
         Q_ASSERT(!m_enabledOutputs.contains(output));
         m_enabledOutputs << output;
-        if (!usesSoftwareCursor()) {
-            qDebug() << "showCursor" ;
-            output->setShowCursor(true);
-        }
-        emit outputAdded(output);
+        emit output->gpu()->outputEnabled(output);
     } else {
-        if (m_enabledOutputs.contains(output)) {
-            //m_enabledOutputs.removeOne(output);
-            m_enabledOutputs.removeAll(output);
-            Q_ASSERT(!m_enabledOutputs.contains(output));
-            emit outputRemoved(output);
-        } 
+        Q_ASSERT(m_enabledOutputs.contains(output));
+        m_enabledOutputs.removeOne(output);
+        Q_ASSERT(!m_enabledOutputs.contains(output));
+        emit output->gpu()->outputDisabled(output);
     }
-    outputDpmsChanged();
+    updateOutputsEnabled();
     checkOutputsAreOn();
     emit screensQueried();
+}
+
+DrmOutput *DrmBackend::findOutput(quint32 connector)
+{
+    auto it = std::find_if(m_outputs.constBegin(), m_outputs.constEnd(), [connector] (DrmOutput *o) {
+        if (o->m_isVirtual) {
+            return false;
+        }
+
+        return o->m_conn->id() == connector;
+    });
+    if (it != m_outputs.constEnd()) {
+        return *it;
+    }
+    return nullptr;
+}
+
+DrmOutput *DrmBackend::findOutput(const QByteArray &uuid)
+{
+    auto it = std::find_if(m_outputs.constBegin(), m_outputs.constEnd(), [uuid] (DrmOutput *o) {
+        return o->m_uuid == uuid;
+    });
+    if (it != m_outputs.constEnd()) {
+        return *it;
+    }
+    return nullptr;
+}
+
+bool DrmBackend::present(DrmBuffer *buffer, DrmOutput *output)
+{
+    if (!buffer || buffer->bufferId() == 0) {
+        if (m_deleteBufferAfterPageFlip) {
+            delete buffer;
+        }
+        return false;
+    }
+
+    if (output->present(buffer)) {
+        m_pageFlipsPending++;
+        if (m_pageFlipsPending == 1 && Compositor::self()) {
+            Compositor::self()->aboutToSwapBuffers();
+        }
+        return true;
+    } else if (m_deleteBufferAfterPageFlip) {
+        delete buffer;
+    }
+    return false;
+}
+
+void DrmBackend::initCursor()
+{
+
+#if HAVE_EGL_STREAMS
+    // Hardware cursors aren't currently supported with EGLStream backend,
+    // possibly an NVIDIA driver bug
+    if (m_useEglStreams) {
+        setSoftWareCursor(true);
+    }
+#endif
+    m_cursorEnabled = waylandServer()->seat()->hasPointer();
+    qDebug() << "m_cursorEnabled" << m_cursorEnabled;
+    connect(waylandServer()->seat(), &KWayland::Server::SeatInterface::hasPointerChanged, this,
+        [this] {
+            m_cursorEnabled = waylandServer()->seat()->hasPointer();
+            qDebug() << "hasPointerChanged m_cursorEnabled" << m_cursorEnabled;
+            if (usesSoftwareCursor()) {
+                return;
+            }
+            for (auto it = m_enabledOutputs.constBegin(); it != m_enabledOutputs.constEnd(); ++it) {
+                if (m_cursorEnabled && (*it)->isDpmsEnabled()) {
+                    if (!(*it)->showCursor()) {
+                        setSoftWareCursor(true);
+                    }
+                } else {
+                    (*it)->hideCursor();
+                }
+            }
+        }
+    );
+    uint64_t capability = 0;
+    QSize cursorSize;
+    cursorSize.setWidth(64);
+    for (auto gpu : m_gpus) {
+        if (drmGetCap(gpu->fd(), DRM_CAP_CURSOR_WIDTH, &capability) == 0) {
+            cursorSize.setWidth(capability);
+        }
+    }
+    cursorSize.setHeight(64);
+    for (auto gpu : m_gpus) {
+        if (drmGetCap(gpu->fd(), DRM_CAP_CURSOR_HEIGHT, &capability) == 0) {
+            cursorSize.setHeight(capability);
+        }
+    }
+    m_cursorSize = cursorSize;
+    // now we have screens and can set cursors, so start tracking
+    connect(this, &DrmBackend::cursorChanged, this, &DrmBackend::updateCursor);
+    connect(Cursor::self(), &Cursor::posChanged, this, &DrmBackend::moveCursor);
+}
+
+void DrmBackend::setCursor()
+{
+    if (m_cursorEnabled) {
+        for (auto it = m_enabledOutputs.constBegin(); it != m_enabledOutputs.constEnd(); ++it) {
+            if ((*it)->isDpmsEnabled()) {
+                if (!(*it)->showCursor()) {
+                    setSoftWareCursor(true);
+                }
+        }
+        }
+    }
+    markCursorAsRendered();
+}
+
+void DrmBackend::updateCursor()
+{
+    if (usesSoftwareCursor()) {
+        return;
+    }
+    if (isCursorHidden()) {
+        return;
+    }
+
+    const QImage &cursorImage = softwareCursor();
+    if (cursorImage.isNull()) {
+        doHideCursor();
+        return;
+    }
+    for (auto it = m_outputs.constBegin(); it != m_outputs.constEnd(); ++it) {
+        (*it)->updateCursor();
+    }
+
+    setCursor();
+    moveCursor();
+}
+
+void DrmBackend::doShowCursor()
+{
+    updateCursor();
+}
+
+void DrmBackend::doHideCursor()
+{
+    if (!m_cursorEnabled || usesSoftwareCursor()) {
+        return;
+    }
+    for (auto it = m_outputs.constBegin(); it != m_outputs.constEnd(); ++it) {
+        (*it)->hideCursor();
+    }
+}
+
+void DrmBackend::moveCursor()
+{
+    if (!m_cursorEnabled || isCursorHidden() || usesSoftwareCursor()) {
+        return;
+    }
+    for (auto it = m_outputs.constBegin(); it != m_outputs.constEnd(); ++it) {
+        (*it)->moveCursor(Cursor::pos());
+    }
+}
+
+Screens *DrmBackend::createScreens(QObject *parent)
+{
+    return new DrmScreens(this, parent);
+}
+
+QPainterBackend *DrmBackend::createQPainterBackend()
+{
+    m_deleteBufferAfterPageFlip = false;
+    return new DrmQPainterBackend(this, primaryGpu());
+}
+
+OpenGLBackend *DrmBackend::createOpenGLBackend()
+{
+#if HAVE_EGL_STREAMS
+    if (m_useEglStreams) {
+        m_deleteBufferAfterPageFlip = false;
+        return new EglStreamBackend(this, primaryGpu());
+    }
+#endif
+
+#if HAVE_GBM
+    if (!m_eglGbmBackend) {
+        m_deleteBufferAfterPageFlip = true;
+        m_eglGbmBackend = new EglGbmBackend(this, primaryGpu());
+    }
+    return m_eglGbmBackend;
+#else
+    return Platform::createOpenGLBackend();
+#endif
+}
+
+OpenGLBackend *DrmBackend::getOpenGLBackend()
+{
+    return m_eglGbmBackend;
+}
+
+bool DrmBackend::requiresCompositing() const
+{
+    return true;
+}
+
+void DrmBackend::updateOutputsEnabled()
+{
+    bool enabled = false;
+    for (auto it = m_enabledOutputs.constBegin(); it != m_enabledOutputs.constEnd(); ++it) {
+        enabled = enabled || (*it)->isDpmsEnabled();
+    }
+    setOutputsEnabled(enabled);
 }
 
 void DrmBackend::configurationChangeRequested(KWayland::Server::OutputConfigurationInterface *config)
@@ -778,227 +727,14 @@ void DrmBackend::configurationChangeRequested(KWayland::Server::OutputConfigurat
     updateCursor();
 }
 
-DrmOutput *DrmBackend::findOutput(quint32 connector)
-{
-    auto it = std::find_if(m_outputs.constBegin(), m_outputs.constEnd(), [connector] (DrmOutput *o) {
-        if (o->m_isVirtual) {
-            return false;
-        }
-        return o->m_conn->id() == connector;
-    });
-    if (it != m_outputs.constEnd()) {
-        return *it;
-    }
-    return nullptr;
-}
-
-DrmOutput *DrmBackend::findOutput(const QByteArray &uuid)
-{
-    auto it = std::find_if(m_outputs.constBegin(), m_outputs.constEnd(), [uuid] (DrmOutput *o) {
-        return o->m_uuid == uuid;
-    });
-    if (it != m_outputs.constEnd()) {
-        return *it;
-    }
-    return nullptr;
-}
-
-void DrmBackend::present(DrmBuffer *buffer, DrmOutput *output)
-{
-    if (!buffer || buffer->bufferId() == 0) {
-        if (m_deleteBufferAfterPageFlip) {
-            delete buffer;
-        }
-        return;
-    }
-
-    if (output->present(buffer)) {
-        m_pageFlipsPending++;
-        if (m_pageFlipsPending == 1 && Compositor::self()) {
-            Compositor::self()->aboutToSwapBuffers();
-        }
-    } else if (m_deleteBufferAfterPageFlip) {
-        delete buffer;
-    }
-}
-
-void DrmBackend::initCursor()
-{
-    m_cursorEnabled = waylandServer()->seat()->hasPointer();
-    qDebug() << "m_cursorEnabled" << m_cursorEnabled;
-    connect(waylandServer()->seat(), &KWayland::Server::SeatInterface::hasPointerChanged, this,
-        [this] {
-            m_cursorEnabled = waylandServer()->seat()->hasPointer();
-            qDebug() << "hasPointerChanged m_cursorEnabled" << m_cursorEnabled;
-            if (usesSoftwareCursor()) {
-                return;
-            }
-            for (auto it = m_enabledOutputs.constBegin(); it != m_enabledOutputs.constEnd(); ++it) {
-                if (m_cursorEnabled && (*it)->isDpmsEnabled()) {
-                    if (!(*it)->showCursor() && drmIsMaster(fd())) {
-                        setSoftWareCursor(true);
-                    }
-                } else {
-                    (*it)->hideCursor();
-                }
-            }
-        }
-    );
-    uint64_t capability = 0;
-    QSize cursorSize;
-    if (drmGetCap(m_fd, DRM_CAP_CURSOR_WIDTH, &capability) == 0) {
-        cursorSize.setWidth(capability);
-    } else {
-        cursorSize.setWidth(64);
-    }
-    if (drmGetCap(m_fd, DRM_CAP_CURSOR_HEIGHT, &capability) == 0) {
-        cursorSize.setHeight(capability);
-    } else {
-        cursorSize.setHeight(64);
-    }
-    m_cursorSize = cursorSize;
-    // now we have screens and can set cursors, so start tracking
-    connect(this, &DrmBackend::cursorChanged, this, &DrmBackend::updateCursor);
-    connect(Cursor::self(), &Cursor::posChanged, this, &DrmBackend::moveCursor);
-}
-
-void DrmBackend::setCursor()
-{
-    if (m_cursorEnabled) {
-        for (auto it = m_enabledOutputs.constBegin(); it != m_enabledOutputs.constEnd(); ++it) {
-            if ((*it)->isDpmsEnabled()) {
-                if (!(*it)->showCursor() && drmIsMaster(fd())) {
-                    setSoftWareCursor(true);
-                }
-            }
-        }
-    }
-    markCursorAsRendered();
-}
-
-void DrmBackend::updateCursor()
-{
-    if (usesSoftwareCursor()) {
-        return;
-    }
-    if (isCursorHidden()) {
-        return;
-    }
-    const QImage &cursorImage = softwareCursor();
-    if (cursorImage.isNull()) {
-        doHideCursor();
-        return;
-    }
-    for (auto it = m_outputs.constBegin(); it != m_outputs.constEnd(); ++it) {
-        (*it)->updateCursor();
-    }
-
-    setCursor();
-    moveCursor();
-}
-
-void DrmBackend::doShowCursor()
-{
-    updateCursor();
-}
-
-void DrmBackend::doHideCursor()
-{
-    if (!m_cursorEnabled) {
-        return;
-    }
-    for (auto it = m_outputs.constBegin(); it != m_outputs.constEnd(); ++it) {
-        (*it)->hideCursor();
-    }
-}
-
-void DrmBackend::moveCursor()
-{
-    if (!m_cursorEnabled || isCursorHidden()) {
-        return;
-    }
-    for (auto it = m_outputs.constBegin(); it != m_outputs.constEnd(); ++it) {
-        (*it)->moveCursor(Cursor::pos());
-    }
-}
-
-Screens *DrmBackend::createScreens(QObject *parent)
-{
-    return new DrmScreens(this, parent);
-}
-
-QPainterBackend *DrmBackend::createQPainterBackend()
-{
-    m_deleteBufferAfterPageFlip = false;
-    return new DrmQPainterBackend(this);
-}
-
-OpenGLBackend *DrmBackend::createOpenGLBackend()
-{
-#if HAVE_GBM
-    m_deleteBufferAfterPageFlip = true;
-    m_eglGbmBackend =  new EglGbmBackend(this);
-    return m_eglGbmBackend;
-#else
-    return Platform::createOpenGLBackend();
-#endif
-}
-
-OpenGLBackend *DrmBackend::getOpenGLBackend()
-{
-    return m_eglGbmBackend;
-}
-
-DmaBufTexture *DrmBackend::createDmaBufTexture(const QSize &size)
-{
-#if HAVE_GBM
-    return GbmDmaBuf::createBuffer(size, m_gbmDevice);
-#else
-    return nullptr;
-#endif
-}
-
-bool DrmBackend::requiresCompositing() const
-{
-    return true;
-}
-
-DrmDumbBuffer *DrmBackend::createBuffer(const QSize &size)
-{
-    DrmDumbBuffer *b = new DrmDumbBuffer(m_fd, size);
-    DTRACE_PROBE2(drm_backend, createBufferSize, size.width(), size.height());
-    return b;
-}
-
-#if HAVE_GBM
-DrmSurfaceBuffer *DrmBackend::createBuffer(const std::shared_ptr<GbmSurface> &surface)
-{
-    DrmSurfaceBuffer *b = new DrmSurfaceBuffer(m_fd, surface);
-    DTRACE_PROBE(drm_backend, createBufferSurface);
-    return b;
-}
-
-DrmSurfaceBuffer *DrmBackend::createBuffer(const std::shared_ptr<GbmSurface> &surface, uint32_t format, QVector<uint64_t> &modifiers)
-{
-    DrmSurfaceBuffer *b = new DrmSurfaceBuffer(m_fd, surface, format, modifiers);
-    DTRACE_PROBE1(drm_backend, createBufferSurfaceFormat, format);
-    return b;
-}
-#endif
-
-void DrmBackend::outputDpmsChanged()
-{
-    bool enabled = false;
-    for (auto it = m_enabledOutputs.constBegin(); it != m_enabledOutputs.constEnd(); ++it) {
-        enabled = enabled || (*it)->isDpmsEnabled();
-    }
-    setOutputsEnabled(enabled);
-}
-
 QVector<CompositingType> DrmBackend::supportedCompositors() const
 {
 #if HAVE_GBM
     return QVector<CompositingType>{OpenGLCompositing, QPainterCompositing};
+#elif HAVE_EGL_STREAMS
+    return m_useEglStreams ?
+        QVector<CompositingType>{OpenGLCompositing, QPainterCompositing} :
+        QVector<CompositingType>{QPainterCompositing};
 #else
     return QVector<CompositingType>{QPainterCompositing};
 #endif
@@ -1011,7 +747,12 @@ QString DrmBackend::supportInformation() const
     s.nospace();
     s << "Name: " << "DRM" << endl;
     s << "Active: " << m_active << endl;
-    s << "Atomic Mode Setting: " << m_atomicModeSetting << endl;
+    for (int g = 0; g < m_gpus.size(); g++) {
+        s << "Atomic Mode Setting on GPU " << g << ": " << m_gpus.at(g)->atomicModeSetting() << endl;
+    }
+#if HAVE_EGL_STREAMS
+    s << "Using EGL Streams: " << m_useEglStreams << endl;
+#endif
     return supportInfo;
 }
 
@@ -1030,6 +771,31 @@ void DrmBackend::changeCursorType(CursorType cursorType)
         showCursor();
         qDebug() << "switch software cursor to hardware cursor";
     }
+}
+
+DmaBufTexture *DrmBackend::createDmaBufTexture(const QSize &size)
+{
+#if HAVE_GBM
+    // gpu_index is a fixed 0 here
+    // as the first GPU is assumed to always be the one used for scene rendering
+    // and this function is only used for Pipewire
+    return GbmDmaBuf::createBuffer(size, m_gpus.at(0)->gbmDevice());
+#else
+    return nullptr;
+#endif
+}
+
+DrmGpu *DrmBackend::primaryGpu() const
+{
+    return m_gpus.isEmpty() ? nullptr : m_gpus.first();
+}
+
+DrmGpu *DrmBackend::findGpu(int sysNum) const
+{
+    auto it = std::find_if(m_gpus.begin(), m_gpus.end(), [sysNum](const auto &gpu) {
+        return gpu->drmId() == sysNum;
+    });
+    return it == m_gpus.end() ? nullptr : *it;
 }
 
 }

--- a/plugins/platforms/drm/drm_backend.h
+++ b/plugins/platforms/drm/drm_backend.h
@@ -11,9 +11,7 @@
 
 #include "drm_buffer.h"
 #if HAVE_GBM
-#include "egl_gbm_backend.h"
 #include "drm_buffer_gbm.h"
-#include "gbm_dmabuf.h"
 #endif
 #include "drm_inputeventfilter.h"
 #include "drm_pointer.h"
@@ -31,17 +29,6 @@ struct gbm_bo;
 struct gbm_device;
 struct gbm_surface;
 
-namespace KWayland
-{
-namespace Server
-{
-class OutputInterface;
-class OutputDeviceInterface;
-class OutputChangeSet;
-class OutputManagementInterface;
-}
-}
-
 namespace KWin
 {
 
@@ -53,7 +40,10 @@ class DrmPlane;
 class DrmCrtc;
 class DrmConnector;
 class GbmSurface;
-
+class EglGbmBackend;
+class Cursor;
+class DrmGpu;
+class UdevDevice;
 
 class KWIN_EXPORT DrmBackend : public Platform
 {
@@ -62,7 +52,7 @@ class KWIN_EXPORT DrmBackend : public Platform
     Q_PLUGIN_METADATA(IID "org.kde.kwin.Platform" FILE "drm.json")
 public:
     explicit DrmBackend(QObject *parent = nullptr);
-    virtual ~DrmBackend();
+    ~DrmBackend() override;
 
     void configurationChangeRequested(KWayland::Server::OutputConfigurationInterface *config) override;
     Screens *createScreens(QObject *parent = nullptr) override;
@@ -74,17 +64,9 @@ public:
     DmaBufTexture *createDmaBufTexture(const QSize &size) override;
 
     void init() override;
-    DrmDumbBuffer *createBuffer(const QSize &size);
-#if HAVE_GBM
-    DrmSurfaceBuffer *createBuffer(const std::shared_ptr<GbmSurface> &surface);
-    DrmSurfaceBuffer *createBuffer(const std::shared_ptr<GbmSurface> &surface,
-                                   uint32_t format, QVector<uint64_t> &modifiers);
-#endif
-    void present(DrmBuffer *buffer, DrmOutput *output);
+    
+    bool present(DrmBuffer *buffer, DrmOutput *output);
 
-    int fd() const {
-        return m_fd;
-    }
     Outputs outputs() const override;
     Outputs enabledOutputs() const override;
     QVector<DrmOutput*> drmOutputs() const {
@@ -94,12 +76,7 @@ public:
         return m_enabledOutputs;
     }
 
-    QVector<DrmPlane*> planes() const {
-        return m_planes;
-    }
-    QVector<DrmPlane*> overlayPlanes() const {
-        return m_overlayPlanes;
-    }
+    void enableOutput(DrmOutput *output, bool enable);
 
     void outputWentOff();
     void checkOutputsAreOn();
@@ -108,27 +85,20 @@ public:
     bool deleteBufferAfterPageFlip() const {
         return m_deleteBufferAfterPageFlip;
     }
-    // returns use of AMS, default is not/legacy
-    bool atomicModeSetting() const {
-        return m_atomicModeSetting;
-    }
 
-    void setGbmDevice(gbm_device *device) {
-        m_gbmDevice = device;
+#if HAVE_EGL_STREAMS
+    bool useEglStreams() const {
+        return m_useEglStreams;
     }
-    gbm_device *gbmDevice() const {
-        return m_gbmDevice;
-    }
+#endif
 
     QVector<CompositingType> supportedCompositors() const override;
 
     QString supportInformation() const override;
 
-    void enableOutput(DrmOutput *output, bool enable);
-
-    void installDefaultDisplay() override;
-
-    void disableMultiScreens() override;
+    bool isCursorEnabled() const {
+        return m_cursorEnabled;
+    };
 
     enum CursorType {
         HardwareCursor, ///< 硬鼠
@@ -140,67 +110,54 @@ public:
     ///
     void changeCursorType(CursorType cursorType = HardwareCursor);
 
+    DrmGpu *primaryGpu() const;
+    DrmGpu *findGpu(int sysNum) const;
+    DrmGpu *addGpu(UdevDevice *device);
+
 public Q_SLOTS:
     void turnOutputsOn();
 
-Q_SIGNALS:
-    /**
-     * Emitted whenever an output is removed/disabled
-     */
-    void outputRemoved(KWin::DrmOutput *output);
-    /**
-     * Emitted whenever an output is added/enabled
-     */
-    void outputAdded(KWin::DrmOutput *output);
-
 protected:
-
     void doHideCursor() override;
     void doShowCursor() override;
-
 private:
+    friend class DrmGpu;
+    void addOutput(DrmOutput* output);
+    void removeOutput(DrmOutput* output);
     static void pageFlipHandler(int fd, unsigned int frame, unsigned int sec, unsigned int usec, void *data);
     void openDrm();
     void activate(bool active);
     void reactivate();
     void deactivate();
-    void updateOutputs();
+    bool updateOutputs();
     void setCursor();
     void updateCursor();
     void moveCursor();
     void initCursor();
-    void outputDpmsChanged();
     void readOutputsConfiguration();
+    void writeOutputsConfiguration();
     QByteArray generateOutputConfigurationUuid() const;
     DrmOutput *findOutput(quint32 connector);
     DrmOutput *findOutput(const QByteArray &uuid);
+    void updateOutputsEnabled();
     QScopedPointer<Udev> m_udev;
     QScopedPointer<UdevMonitor> m_udevMonitor;
-    int m_fd = -1;
-    int m_drmId = 0;
-    // all crtcs
-    QVector<DrmCrtc*> m_crtcs;
-    // all connectors
-    QVector<DrmConnector*> m_connectors;
+    
     // active output pipelines (planes + crtc + encoder + connector)
     QVector<DrmOutput*> m_outputs;
     // active and enabled pipelines (above + wl_output)
     QVector<DrmOutput*> m_enabledOutputs;
 
     bool m_deleteBufferAfterPageFlip;
-    bool m_atomicModeSetting = false;
     bool m_cursorEnabled = false;
     QSize m_cursorSize;
     int m_pageFlipsPending = 0;
     bool m_active = false;
-    // all available planes: primarys, cursors and overlays
-    QVector<DrmPlane*> m_planes;
-    QVector<DrmPlane*> m_overlayPlanes;
+#if HAVE_EGL_STREAMS
+    bool m_useEglStreams = false;
+#endif
+    QVector<DrmGpu*> m_gpus;
     QScopedPointer<DpmsInputEventFilter> m_dpmsFilter;
-    KWayland::Server::OutputManagementInterface *m_outputManagement = nullptr;
-    gbm_device *m_gbmDevice = nullptr;
-    DrmOutput *m_defaultOutput = nullptr;
-    bool m_disableMultiScreens = false;
     EglGbmBackend *m_eglGbmBackend = nullptr;
 };
 

--- a/plugins/platforms/drm/drm_buffer.cpp
+++ b/plugins/platforms/drm/drm_buffer.cpp
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "drm_buffer.h"
+#include "drm_buffer_gbm.h"
 
 #include "logging.h"
 
 // system
 #include <sys/mman.h>
 #include <errno.h>
+#include <unistd.h>
 // drm
 #include <xf86drm.h>
 #include <xf86drmMode.h>
@@ -73,6 +75,10 @@ bool DrmDumbBuffer::needsModeChange(DrmBuffer *b) const {
 
 bool DrmDumbBuffer::map(QImage::Format format)
 {
+    if (m_image && !m_image->isNull())
+	    return true;
+
+    delete m_image;
     if (!m_handle || !m_bufferId) {
         return false;
     }
@@ -89,6 +95,32 @@ bool DrmDumbBuffer::map(QImage::Format format)
     m_memory = address;
     m_image = new QImage((uchar*)m_memory, m_size.width(), m_size.height(), m_stride, format);
     return !m_image->isNull();
+}
+
+bool DrmDumbBuffer::copyGbmToDumbBuffer(DrmBuffer *buffer)
+{
+    DrmSurfaceBuffer* gbmbuf = static_cast<DrmSurfaceBuffer *>(buffer);
+    if(gbmbuf) {
+        unsigned int dmaFd = gbmbuf->getFd();
+
+        if (gbmbuf->hasBo()) {
+            gbm_bo *dmaBo = gbmbuf->getBo();
+            quint32 stride = gbm_bo_get_stride(dmaBo);
+            QSize dmaSize = QSize(gbm_bo_get_width(dmaBo), gbm_bo_get_height(dmaBo));
+
+            unsigned char *address = static_cast<unsigned char *>(mmap(nullptr, stride * dmaSize.height(), PROT_READ, MAP_SHARED, dmaFd, 0));
+            if (address == MAP_FAILED) {
+                return false;
+            }
+            memcpy(m_memory, address, stride * dmaSize.height());
+            munmap(address, stride * dmaSize.height());
+            close(dmaFd);
+            return true;
+        }
+        return false;
+    }
+
+    return false;
 }
 
 }

--- a/plugins/platforms/drm/drm_buffer.h
+++ b/plugins/platforms/drm/drm_buffer.h
@@ -7,6 +7,8 @@
 #ifndef KWIN_DRM_BUFFER_H
 #define KWIN_DRM_BUFFER_H
 
+#include <gbm.h>
+
 #include <QImage>
 #include <QSize>
 
@@ -50,6 +52,7 @@ public:
     bool needsModeChange(DrmBuffer *b) const override;
 
     bool map(QImage::Format format = QImage::Format_RGB32);
+    bool copyGbmToDumbBuffer(DrmBuffer *buffer);
     quint32 handle() const {
         return m_handle;
     }

--- a/plugins/platforms/drm/drm_gpu.cpp
+++ b/plugins/platforms/drm/drm_gpu.cpp
@@ -1,0 +1,292 @@
+/*
+    KWin - the KDE window manager
+    This file is part of the KDE project.
+
+    SPDX-FileCopyrightText: 2020 Xaver Hugl <xaver.hugl@gmail.com>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "drm_gpu.h"
+
+#include "drm_backend.h"
+#include "drm_output.h"
+#include "drm_object_connector.h"
+#include "drm_object_crtc.h"
+#include "abstract_egl_backend.h"
+#include "logging.h"
+
+#if HAVE_GBM
+#include "egl_gbm_backend.h"
+#include <gbm.h>
+#include "gbm_dmabuf.h"
+#endif
+// system
+#include <algorithm>
+#include <unistd.h>
+// drm
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#include <libdrm/drm_mode.h>
+
+namespace KWin
+{
+DrmGpu::DrmGpu(DrmBackend *backend, QByteArray devNode, int fd, int drmId) : m_backend(backend), m_devNode(devNode), m_fd(fd), m_drmId(drmId), m_atomicModeSetting(false), m_useEglStreams(false), m_gbmDevice(nullptr)
+{
+    
+}
+
+DrmGpu::~DrmGpu()
+{
+#if HAVE_GBM
+    gbm_device_destroy(m_gbmDevice);
+#endif
+    qDeleteAll(m_crtcs);
+    qDeleteAll(m_connectors);
+    qDeleteAll(m_planes);
+    close(m_fd);
+}
+
+void DrmGpu::tryAMS()
+{
+    m_atomicModeSetting = false;
+    if (drmSetClientCap(m_fd, DRM_CLIENT_CAP_ATOMIC, 1) == 0) {
+        bool ams = true;
+        QVector<DrmPlane*> planes, overlayPlanes;
+        
+        ScopedDrmPointer<drmModePlaneRes, &drmModeFreePlaneResources> planeResources(drmModeGetPlaneResources(m_fd));
+        if (!planeResources) {
+            qCWarning(KWIN_DRM) << "Failed to get plane resources. Falling back to legacy mode on GPU " << m_devNode;
+            ams = false;
+        }
+        if (ams) {
+            qCDebug(KWIN_DRM) << "Using Atomic Mode Setting on gpu" << m_devNode;
+            qCDebug(KWIN_DRM) << "Number of planes on GPU" << m_devNode << ":" << planeResources->count_planes;
+            
+            // create the plane objects
+            for (unsigned int i = 0; i < planeResources->count_planes; ++i) {
+                DrmScopedPointer<drmModePlane> kplane(drmModeGetPlane(m_fd, planeResources->planes[i]));
+                DrmPlane *p = new DrmPlane(kplane->plane_id, m_fd);
+                if (p->atomicInit()) {
+                    planes << p;
+                    if (p->type() == DrmPlane::TypeIndex::Overlay) {
+                        overlayPlanes << p;
+                    }
+                } else {
+                    delete p;
+                }
+            }
+
+            if (planes.isEmpty()) {
+                qCWarning(KWIN_DRM) << "Failed to create any plane. Falling back to legacy mode on GPU " << m_devNode;
+                ams = false;
+            }
+        }
+        if (!ams) {
+            for (auto p : planes) {
+                delete p;
+            }
+            planes.clear();
+            overlayPlanes.clear();
+        }
+        m_atomicModeSetting = ams;
+        m_planes = planes;
+        m_overlayPlanes = overlayPlanes;
+    } else {
+        qCWarning(KWIN_DRM) << "drmSetClientCap for Atomic Mode Setting failed. Using legacy mode on GPU" << m_devNode;
+    }
+}
+
+bool DrmGpu::updateOutputs()
+{
+    auto oldConnectors = m_connectors;
+    auto oldCrtcs = m_crtcs;
+    ScopedDrmPointer<_drmModeRes, &drmModeFreeResources> resources(drmModeGetResources(m_fd));
+    if (!resources) {
+        qCWarning(KWIN_DRM) << "drmModeGetResources failed";
+        return false;
+    }
+
+    for (int i = 0; i < resources->count_connectors; ++i) {
+        const uint32_t currentConnector = resources->connectors[i];
+        auto it = std::find_if(m_connectors.constBegin(), m_connectors.constEnd(), [currentConnector] (DrmConnector *c) { return c->id() == currentConnector; });
+        if (it == m_connectors.constEnd()) {
+            auto c = new DrmConnector(currentConnector, m_fd);
+            if (m_atomicModeSetting && !c->atomicInit()) {
+                delete c;
+                continue;
+            }
+            m_connectors << c;
+        } else {
+            oldConnectors.removeOne(*it);
+        }
+    }
+
+    for (int i = 0; i < resources->count_crtcs; ++i) {
+        const uint32_t currentCrtc = resources->crtcs[i];
+        auto it = std::find_if(m_crtcs.constBegin(), m_crtcs.constEnd(), [currentCrtc] (DrmCrtc *c) { return c->id() == currentCrtc; });
+        if (it == m_crtcs.constEnd()) {
+            auto c = new DrmCrtc(currentCrtc, m_backend, this, i);
+            if (m_atomicModeSetting && !c->atomicInit()) {
+                delete c;
+                continue;
+            }
+            m_crtcs << c;
+        } else {
+            oldCrtcs.removeOne(*it);
+        }
+    }
+
+    for (auto c : qAsConst(oldConnectors)) {
+        m_connectors.removeOne(c);
+    }
+    for (auto c : qAsConst(oldCrtcs)) {
+        m_crtcs.removeOne(c);
+    }
+    
+    QVector<DrmOutput*> connectedOutputs;
+    QVector<DrmConnector*> pendingConnectors;
+
+    // split up connected connectors in already or not yet assigned ones
+    for (DrmConnector *con : qAsConst(m_connectors)) {
+        if (!con->isConnected()) {
+            continue;
+        }
+
+        if (DrmOutput *o = findOutput(con->id())) {
+            connectedOutputs << o;
+        } else {
+            pendingConnectors << con;
+        }
+    }
+
+    // check for outputs which got removed
+    QVector<DrmOutput*> removedOutputs;
+    auto it = m_outputs.begin();
+    while (it != m_outputs.end()) {
+        if (connectedOutputs.contains(*it)) {
+            it++;
+            continue;
+        }
+        DrmOutput *removed = *it;
+        it = m_outputs.erase(it);
+        removedOutputs.append(removed);
+    }
+    
+    for (DrmConnector *con : qAsConst(pendingConnectors)) {
+	ScopedDrmPointer<_drmModeConnector, &drmModeFreeConnector> connector(drmModeGetConnector(m_fd, con->id()));
+        if (!connector) {
+            continue;
+        }
+        if (connector->count_modes == 0) {
+            continue;
+        }
+        bool outputDone = false;
+
+        QVector<uint32_t> encoders = con->encoders();
+        for (auto encId : qAsConst(encoders)) {
+            ScopedDrmPointer<_drmModeEncoder, &drmModeFreeEncoder> encoder(drmModeGetEncoder(m_fd, encId));
+            if (!encoder) {
+                continue;
+            }
+            for (DrmCrtc *crtc : qAsConst(m_crtcs)) {
+                if (!(encoder->possible_crtcs & (1 << crtc->resIndex()))) {
+                    continue;
+                }
+                
+                // check if crtc isn't used yet -- currently we don't allow multiple outputs on one crtc (cloned mode)
+                auto it = std::find_if(connectedOutputs.constBegin(), connectedOutputs.constEnd(),
+                    [crtc] (DrmOutput *o) {
+                        return o->m_crtc == crtc;
+                    }
+                );
+                if (it != connectedOutputs.constEnd()) {
+                    continue;
+                }
+
+                // we found a suitable encoder+crtc
+                // TODO: we could avoid these lib drm calls if we store all struct data in DrmCrtc and DrmConnector in the beginning
+                ScopedDrmPointer<_drmModeCrtc, &drmModeFreeCrtc> modeCrtc(drmModeGetCrtc(m_fd, crtc->id()));
+                if (!modeCrtc) {
+                    continue;
+                }
+
+                DrmOutput *output = new DrmOutput(this->m_backend, this);
+                con->setOutput(output);
+                output->m_conn = con;
+                crtc->setOutput(output);
+                output->m_crtc = crtc;
+
+                if (modeCrtc->mode_valid) {
+                    output->m_mode = modeCrtc->mode;
+                } else {
+                    output->m_mode = connector->modes[0];
+                }
+                qCDebug(KWIN_DRM) << "For new output use mode " << output->m_mode.name;
+                if (!output->init(connector.data())) {
+                    qCWarning(KWIN_DRM) << "Failed to create output for connector " << con->id();
+                    delete output;
+                    continue;
+                }
+                if (!output->initCursor(m_backend->m_cursorSize)) {
+                    m_backend->setSoftWareCursor(true);
+                }
+                qCDebug(KWIN_DRM) << "Found new output with uuid" << output->uuid();
+
+                connectedOutputs << output;
+                emit outputAdded(output);
+                outputDone = true;
+                break;
+            }
+            if (outputDone) {
+                break;
+            }
+        }
+    }
+    std::sort(connectedOutputs.begin(), connectedOutputs.end(), [] (DrmOutput *a, DrmOutput *b) { return a->m_conn->id() < b->m_conn->id(); });
+    m_outputs = connectedOutputs;
+    
+    for(DrmOutput *removedOutput : removedOutputs) {
+        emit outputRemoved(removedOutput);
+        removedOutput->teardown();
+//        removedOutput->m_crtc = nullptr;
+//        removedOutput->m_conn = nullptr;
+    }
+    
+    qDeleteAll(oldConnectors);
+    qDeleteAll(oldCrtcs);
+    return true;
+}
+
+DrmOutput *DrmGpu::findOutput(quint32 connector)
+{
+    auto it = std::find_if(m_outputs.constBegin(), m_outputs.constEnd(), [connector] (DrmOutput *o) {
+        return o->m_conn->id() == connector;
+    });
+    if (it != m_outputs.constEnd()) {
+        return *it;
+    }
+    return nullptr;
+}
+
+DrmSurfaceBuffer *DrmGpu::createBuffer(const std::shared_ptr<GbmSurface> &surface)
+{
+    DrmSurfaceBuffer *b = new DrmSurfaceBuffer(m_fd, surface);
+    return b;
+}
+
+DrmSurfaceBuffer *DrmGpu::createBuffer(const std::shared_ptr<GbmSurface> &surface, uint32_t format, QVector<uint64_t> &modifiers)
+{
+    DrmSurfaceBuffer *b = new DrmSurfaceBuffer(m_fd, surface, format, modifiers);
+    return b;
+}
+
+void DrmGpu::handleGPURemove()
+{
+    for (DrmOutput *o : m_outputs) {
+       m_backend->removeOutput(o);
+       o->deleteLater();
+    }
+}
+
+}

--- a/plugins/platforms/drm/drm_gpu.h
+++ b/plugins/platforms/drm/drm_gpu.h
@@ -1,0 +1,118 @@
+/*
+    KWin - the KDE window manager
+    This file is part of the KDE project.
+
+    SPDX-FileCopyrightText: 2020 Xaver Hugl <xaver.hugl@gmail.com>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef DRM_GPU_H
+#define DRM_GPU_H
+
+#include <qobject.h>
+#include <QVector>
+#include <memory>
+
+#include "drm_buffer.h"
+
+struct gbm_device;
+
+namespace KWin
+{
+    
+class DrmOutput;
+class DrmPlane;
+class DrmCrtc;
+class DrmConnector;
+class DrmBackend;
+class DrmSurfaceBuffer;
+class GbmSurface;
+class AbstractEglBackend;
+    
+class DrmGpu : public QObject
+{
+    Q_OBJECT
+public:
+    DrmGpu(DrmBackend *backend, QByteArray devNode, int fd, int drmId);
+    ~DrmGpu();
+    
+    // getters
+    QVector<DrmOutput*> outputs() const {
+        return m_outputs;
+    }
+    
+    int fd() const {
+        return m_fd;
+    }
+    
+    int drmId() const {
+        return m_drmId;
+    }
+    
+    bool atomicModeSetting() const {
+        return m_atomicModeSetting;
+    }
+    
+    QByteArray devNode() const {
+        return m_devNode;
+    }
+    
+    gbm_device *gbmDevice() const {
+        return m_gbmDevice;
+    }
+    
+    QVector<DrmPlane*> planes() const {
+        return m_planes;
+    }
+    
+    void setGbmDevice(gbm_device *d) {
+        m_gbmDevice = d;
+    }
+    
+    DrmDumbBuffer *createBuffer(const QSize &size) const {
+        return new DrmDumbBuffer(m_fd, size);
+    }
+
+    DrmSurfaceBuffer *createBuffer(const std::shared_ptr<GbmSurface> &surface);
+    DrmSurfaceBuffer *createBuffer(const std::shared_ptr<GbmSurface> &surface,
+                                   uint32_t format, QVector<uint64_t> &modifiers);
+    void handleGPURemove();
+Q_SIGNALS:
+    void outputAdded(DrmOutput *output);
+    void outputRemoved(DrmOutput *output);
+    void outputEnabled(DrmOutput *output);
+    void outputDisabled(DrmOutput *output);
+    
+protected:
+    
+    friend class DrmBackend;
+    void tryAMS();
+    bool updateOutputs();
+    
+private:
+    DrmOutput *findOutput(quint32 connector);
+    
+    DrmBackend* const m_backend;
+    
+    const QByteArray m_devNode;
+    const int m_fd;
+    const int m_drmId;
+    bool m_atomicModeSetting;
+    bool m_useEglStreams;
+    gbm_device* m_gbmDevice;
+    
+// all available planes: primarys, cursors and overlays
+    QVector<DrmPlane*> m_planes;
+    QVector<DrmPlane*> m_overlayPlanes;
+    // crtcs
+    QVector<DrmCrtc*> m_crtcs;
+    // connectors
+    QVector<DrmConnector*> m_connectors;
+    // active output pipelines (planes + crtc + encoder + connector)
+    QVector<DrmOutput*> m_outputs;
+};
+
+}
+
+#endif // DRM_GPU_H

--- a/plugins/platforms/drm/drm_object_crtc.h
+++ b/plugins/platforms/drm/drm_object_crtc.h
@@ -32,11 +32,13 @@ struct GammaRamp;
 class DrmBackend;
 class DrmBuffer;
 class DrmDumbBuffer;
+class GammaRamp;
+class DrmGpu;
 
 class DrmCrtc : public DrmObject
 {
 public:
-    DrmCrtc(uint32_t crtc_id, DrmBackend *backend, int resIndex);
+    DrmCrtc(uint32_t crtc_id, DrmBackend *backend, DrmGpu *gpu, int resIndex);
 
     virtual ~DrmCrtc();
 
@@ -72,6 +74,10 @@ public:
     }
     bool setGammaRamp(const ColorCorrect::GammaRamp &gamma);
     const ColorCorrect::GammaRamp* getGammaRamp() const;
+    
+    DrmGpu *gpu() {
+        return m_gpu;
+    }
 
 private:
     int m_resIndex;
@@ -83,6 +89,7 @@ private:
     DrmBackend *m_backend;
 
     ColorCorrect::GammaRamp *m_gammaRamp = nullptr;
+    DrmGpu *m_gpu;
 };
 
 }

--- a/plugins/platforms/drm/drm_output.h
+++ b/plugins/platforms/drm/drm_output.h
@@ -27,6 +27,8 @@ class DrmDumbBuffer;
 class DrmPlane;
 class DrmConnector;
 class DrmCrtc;
+class Cursor;
+class DrmGpu;
 
 class KWIN_EXPORT DrmOutput : public AbstractOutput
 {
@@ -106,16 +108,23 @@ public:
         return m_primaryPlane;
     }
 
+    bool hardwareTransforms() const;
+    
+    DrmGpu *gpu() {
+        return m_gpu;
+    }
+
     bool m_isVirtual = false;
 
 Q_SIGNALS:
     void dpmsChanged();
 
 private:
+    friend class DrmGpu;
     friend class DrmBackend;
     friend class DrmCrtc;   // TODO: For use of setModeLegacy. Remove later when we allow multiple connectors per crtc
                             //       and save the connector ids in the DrmCrtc instance.
-    DrmOutput(DrmBackend *backend);
+    DrmOutput(DrmBackend *backend, DrmGpu* gpu);
 
     bool presentAtomically(DrmBuffer *buffer);
 
@@ -155,6 +164,7 @@ private:
     const ColorCorrect::GammaRamp* getGammaRamp() override;
 
     DrmBackend *m_backend;
+    DrmGpu *m_gpu;
     DrmConnector *m_conn = nullptr;
     DrmCrtc *m_crtc = nullptr;
     bool m_lastGbm = false;
@@ -168,8 +178,8 @@ private:
     bool m_scalingCapable = false;
 
     uint32_t m_blobId = 0;
-    DrmPlane* m_primaryPlane = nullptr;
-    DrmPlane* m_cursorPlane = nullptr;
+    DrmPlane *m_primaryPlane = nullptr;
+    DrmPlane *m_cursorPlane = nullptr;
     QVector<DrmPlane*> m_nextPlanesFlipList;
     bool m_pageFlipPending = false;
     bool m_dpmsAtomicOffPending = false;

--- a/plugins/platforms/drm/drm_pointer.h
+++ b/plugins/platforms/drm/drm_pointer.h
@@ -9,6 +9,8 @@
 
 #include <QScopedPointer>
 
+#include <xf86drmMode.h>
+
 namespace KWin
 {
 
@@ -21,6 +23,120 @@ struct DrmCleanup
     }
 };
 template <typename T, void (*cleanupFunc)(T*)> using ScopedDrmPointer = QScopedPointer<T, DrmCleanup<T, cleanupFunc>>;
+
+template <typename T>
+struct DrmDeleter;
+
+template <>
+struct DrmDeleter<drmModeAtomicReq>
+{
+    static void cleanup(drmModeAtomicReq *req)
+    {
+        drmModeAtomicFree(req);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModeConnector>
+{
+    static void cleanup(drmModeConnector *connector)
+    {
+        drmModeFreeConnector(connector);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModeCrtc>
+{
+    static void cleanup(drmModeCrtc *crtc)
+    {
+        drmModeFreeCrtc(crtc);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModeFB>
+{
+    static void cleanup(drmModeFB *fb)
+    {
+        drmModeFreeFB(fb);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModeEncoder>
+{
+    static void cleanup(drmModeEncoder *encoder)
+    {
+        drmModeFreeEncoder(encoder);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModeModeInfo>
+{
+    static void cleanup(drmModeModeInfo *info)
+    {
+        drmModeFreeModeInfo(info);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModeObjectProperties>
+{
+    static void cleanup(drmModeObjectProperties *properties)
+    {
+        drmModeFreeObjectProperties(properties);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModePlane>
+{
+    static void cleanup(drmModePlane *plane)
+    {
+        drmModeFreePlane(plane);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModePlaneRes>
+{
+    static void cleanup(drmModePlaneRes *resources)
+    {
+        drmModeFreePlaneResources(resources);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModePropertyRes>
+{
+    static void cleanup(drmModePropertyRes *property)
+    {
+        drmModeFreeProperty(property);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModePropertyBlobRes>
+{
+    static void cleanup(drmModePropertyBlobRes *blob)
+    {
+        drmModeFreePropertyBlob(blob);
+    }
+};
+
+template <>
+struct DrmDeleter<drmModeRes>
+{
+    static void cleanup(drmModeRes *resources)
+    {
+        drmModeFreeResources(resources);
+    }
+};
+
+template <typename T>
+using DrmScopedPointer = QScopedPointer<T, DrmDeleter<T>>;
 
 }
 

--- a/plugins/platforms/drm/egl_gbm_backend.h
+++ b/plugins/platforms/drm/egl_gbm_backend.h
@@ -18,8 +18,10 @@ namespace KWin
 {
 class DrmBackend;
 class DrmBuffer;
+class DrmDumbBuffer;
 class DrmOutput;
 class GbmSurface;
+class DrmGpu;
 
 /**
  * @brief OpenGL Backend using Egl on a GBM surface.
@@ -28,7 +30,7 @@ class EglGbmBackend : public AbstractEglBackend
 {
     Q_OBJECT
 public:
-    EglGbmBackend(DrmBackend *b);
+    EglGbmBackend(DrmBackend *b, DrmGpu *gpu);
     virtual ~EglGbmBackend();
     void screenGeometryChanged(const QSize &size) override;
     SceneOpenGLTexturePrivate *createBackendTexture(SceneOpenGLTexture *texture) override;
@@ -44,6 +46,8 @@ public:
         return m_dmaFd;
     }
 
+    void connectToGpu(DrmGpu *gpu);
+
 protected:
     void present() override;
     void cleanupSurfaces() override;
@@ -57,6 +61,7 @@ private:
     struct Output {
         DrmOutput *output = nullptr;
         DrmBuffer *buffer = nullptr;
+        DrmDumbBuffer *dumbBuffer = nullptr;
         std::shared_ptr<GbmSurface> gbmSurface;
         EGLSurface eglSurface = EGL_NO_SURFACE;
         int bufferAge = 0;
@@ -96,6 +101,7 @@ private:
     void renderPostprocess(Output& output);
 
     DrmBackend *m_backend;
+    DrmGpu *m_gpu;
     QVector<Output> m_outputs;
     QScopedPointer<RemoteAccessManager> m_remoteaccessManager;
     friend class EglGbmTexture;

--- a/plugins/platforms/drm/scene_qpainter_drm_backend.cpp
+++ b/plugins/platforms/drm/scene_qpainter_drm_backend.cpp
@@ -8,21 +8,23 @@
 #include "drm_backend.h"
 #include "drm_output.h"
 #include "logind.h"
+#include "drm_gpu.h"
 
 namespace KWin
 {
 
-DrmQPainterBackend::DrmQPainterBackend(DrmBackend *backend)
+DrmQPainterBackend::DrmQPainterBackend(DrmBackend *backend, DrmGpu *gpu)
     : QObject()
     , QPainterBackend()
     , m_backend(backend)
+    , m_gpu(gpu)
 {
     const auto outputs = m_backend->drmOutputs();
     for (auto output: outputs) {
         initOutput(output);
     }
-    connect(m_backend, &DrmBackend::outputAdded, this, &DrmQPainterBackend::initOutput);
-    connect(m_backend, &DrmBackend::outputRemoved, this,
+    connect(m_gpu, &DrmGpu::outputEnabled, this, &DrmQPainterBackend::initOutput);
+    connect(m_gpu, &DrmGpu::outputDisabled,  this,
         [this] (DrmOutput *o) {
             auto it = std::find_if(m_outputs.begin(), m_outputs.end(),
                 [o] (const Output &output) {
@@ -51,7 +53,7 @@ void DrmQPainterBackend::initOutput(DrmOutput *output)
 {
     Output o;
     auto initBuffer = [&o, output, this] (int index) {
-        o.buffer[index] = m_backend->createBuffer(output->pixelSize());
+        o.buffer[index] = output->gpu()->createBuffer(output->pixelSize());
         if (o.buffer[index]->map()) {
             o.buffer[index]->image()->fill(Qt::black);
         }
@@ -69,7 +71,7 @@ void DrmQPainterBackend::initOutput(DrmOutput *output)
             delete (*it).buffer[0];
             delete (*it).buffer[1];
             auto initBuffer = [it, output, this] (int index) {
-                it->buffer[index] = m_backend->createBuffer(output->pixelSize());
+                it->buffer[index] = output->gpu()->createBuffer(output->pixelSize());
                 if (it->buffer[index]->map()) {
                     it->buffer[index]->image()->fill(Qt::black);
                 }

--- a/plugins/platforms/drm/scene_qpainter_drm_backend.h
+++ b/plugins/platforms/drm/scene_qpainter_drm_backend.h
@@ -16,12 +16,13 @@ namespace KWin
 class DrmBackend;
 class DrmDumbBuffer;
 class DrmOutput;
+class DrmGpu;
 
 class DrmQPainterBackend : public QObject, public QPainterBackend
 {
     Q_OBJECT
 public:
-    DrmQPainterBackend(DrmBackend *backend);
+    DrmQPainterBackend(DrmBackend *backend, DrmGpu *gpu);
     virtual ~DrmQPainterBackend();
 
     QImage *buffer() override;
@@ -41,6 +42,7 @@ private:
     };
     QVector<Output> m_outputs;
     DrmBackend *m_backend;
+    DrmGpu *m_gpu;
 };
 }
 

--- a/plugins/platforms/fbdev/fb_backend.cpp
+++ b/plugins/platforms/fbdev/fb_backend.cpp
@@ -71,7 +71,10 @@ void FramebufferBackend::openFrameBuffer()
     VirtualTerminal::self()->init();
     QString framebufferDevice = deviceIdentifier().constData();
     if (framebufferDevice.isEmpty()) {
-        framebufferDevice = QString(Udev().primaryFramebuffer()->devNode());
+        auto framebuffers = Udev().listFramebuffers();
+        if (framebuffers.empty())
+            return;
+        framebufferDevice = QString(framebuffers[0]->devNode());
     }
     int fd = LogindIntegration::self()->takeDevice(framebufferDevice.toUtf8().constData());
     qCDebug(KWIN_FB) << "Using frame buffer device:" << framebufferDevice;

--- a/udev.cpp
+++ b/udev.cpp
@@ -40,7 +40,7 @@ public:
     };
     void addMatch(Match match, const char *name);
     void scan();
-    UdevDevice::Ptr find(std::function<bool(const UdevDevice::Ptr &)> test);
+    std::vector<UdevDevice::Ptr> find();
 
 private:
     Udev *m_udev;
@@ -89,80 +89,100 @@ void UdevEnumerate::scan()
     udev_enumerate_scan_devices(m_enumerate.data());
 }
 
-UdevDevice::Ptr UdevEnumerate::find(std::function<bool(const UdevDevice::Ptr &device)> test)
+std::vector<UdevDevice::Ptr> UdevEnumerate::find()
 {
-    if (m_enumerate.isNull()) {
-        return UdevDevice::Ptr();
+    if (!m_enumerate) {
+        return {};
     }
-    QString defaultSeat = QStringLiteral("seat0");
-    udev_list_entry *it = udev_enumerate_get_list_entry(m_enumerate.data());
-    UdevDevice::Ptr firstFound;
+    std::vector<UdevDevice::Ptr> vect;
+    udev_list_entry *it = udev_enumerate_get_list_entry(m_enumerate.get());
     while (it) {
         auto current = it;
         it = udev_list_entry_get_next(it);
         auto device = m_udev->deviceFromSyspath(udev_list_entry_get_name(current));
-        if (!device) {
-            continue;
-        }
-        QString deviceSeat = device->property("ID_SEAT");
-        if (deviceSeat.isEmpty()) {
-            deviceSeat = defaultSeat;
-        }
-        if (deviceSeat != LogindIntegration::self()->seat()) {
-            continue;
-        }
-        if (test(device)) {
-            return device;
-        }
-        if (!firstFound) {
-            firstFound.swap(device);
+        if (device) {
+            vect.push_back(std::move(device));
         }
     }
-    return firstFound;
+    return vect;
 }
 
-UdevDevice::Ptr Udev::primaryGpu()
+std::vector<UdevDevice::Ptr> Udev::listGPUs()
 {
     if (!m_udev) {
-        return UdevDevice::Ptr();
+        std::vector<UdevDevice::Ptr> vect;
+        vect.push_back(UdevDevice::Ptr());
+        return vect;
     }
-    UdevEnumerate enumerate(this);
-    enumerate.addMatch(UdevEnumerate::Match::SubSystem, "drm");
-    enumerate.addMatch(UdevEnumerate::Match::SysName, "card[0-9]*");
-    enumerate.scan();
-    return enumerate.find([](const UdevDevice::Ptr &device) {
-        auto pci = device->getParentWithSubsystemDevType("pci");
-        if (!pci) {
-            return false;
-        }
-        const char *systAttrValue = udev_device_get_sysattr_value(pci, "boot_vga");
+#if defined(Q_OS_FREEBSD)
+    std::vector<UdevDevice::Ptr> r;
+    r.push_back(deviceFromSyspath("/dev/dri/card6"));
+    return r;
+#else
+    UdevEnumerate enumerate1(this);
+    enumerate1.addMatch(UdevEnumerate::Match::SubSystem, "drm");
+    enumerate1.addMatch(UdevEnumerate::Match::SysName, "card[0-9]");
+    enumerate1.scan();
+    auto vect1 = enumerate1.find();
+
+    std::sort(vect1.begin(), vect1.end(), [](const UdevDevice::Ptr &device1, const UdevDevice::Ptr &device2) {
+        QString devNode1 = device1->devNode();
+        QString devNode2 = device2->devNode();
+
+        devNode1.replace("/dev/dri/card", "");
+        devNode2.replace("/dev/dri/card", "");
+
+        return devNode1.toInt() < devNode2.toInt();
+    });
+
+    std::sort(vect1.begin(), vect1.end(), [](const UdevDevice::Ptr &device1, const UdevDevice::Ptr &device2) {
+        auto pci1 = device1->getParentWithSubsystemDevType("pci");
+        auto pci2 = device2->getParentWithSubsystemDevType("pci");
+        // if set as boot GPU, prefer 1
+        const char *systAttrValue = udev_device_get_sysattr_value(pci1, "boot_vga");
         if (systAttrValue && qstrcmp(systAttrValue, "1") == 0) {
             return true;
         }
-        return false;
+        // if set as boot GPU, prefer 2
+        systAttrValue = udev_device_get_sysattr_value(pci2, "boot_vga");
+        if (systAttrValue && qstrcmp(systAttrValue, "1") == 0) {
+            return false;
+        }
+        return udev_device_get_sysnum(pci1) > udev_device_get_sysnum(pci2);
     });
+
+    return vect1;
+#endif
 }
 
-UdevDevice::Ptr Udev::primaryFramebuffer()
+std::vector<UdevDevice::Ptr> Udev::listFramebuffers()
 {
     if (!m_udev) {
-        return UdevDevice::Ptr();
+        std::vector<UdevDevice::Ptr> vect;
+        vect.push_back(UdevDevice::Ptr());
+        return vect;
     }
     UdevEnumerate enumerate(this);
     enumerate.addMatch(UdevEnumerate::Match::SubSystem, "graphics");
-    enumerate.addMatch(UdevEnumerate::Match::SysName, "fb[0-9]*");
+    enumerate.addMatch(UdevEnumerate::Match::SysName, "fb[0-9]");
     enumerate.scan();
-    return enumerate.find([](const UdevDevice::Ptr &device) {
-        auto pci = device->getParentWithSubsystemDevType("pci");
-        if (!pci) {
-            return false;
-        }
-        const char *systAttrValue = udev_device_get_sysattr_value(pci, "boot_vga");
+    auto vect = enumerate.find();
+    std::sort(vect.begin(), vect.end(), [](const UdevDevice::Ptr &device1, const UdevDevice::Ptr &device2) {
+        auto pci1 = device1->getParentWithSubsystemDevType("pci");
+        auto pci2 = device2->getParentWithSubsystemDevType("pci");
+        // if set as boot GPU, prefer 1
+        const char *systAttrValue = udev_device_get_sysattr_value(pci1, "boot_vga");
         if (systAttrValue && qstrcmp(systAttrValue, "1") == 0) {
             return true;
         }
-        return false;
+        // if set as boot GPU, prefer 2
+        systAttrValue = udev_device_get_sysattr_value(pci2, "boot_vga");
+        if (systAttrValue && qstrcmp(systAttrValue, "1") == 0) {
+            return false;
+        }
+        return udev_device_get_sysnum(pci1) > udev_device_get_sysnum(pci2);
     });
+    return vect;
 }
 
 UdevDevice::Ptr Udev::deviceFromSyspath(const char *syspath)
@@ -231,6 +251,11 @@ bool UdevDevice::hasProperty(const char *key, const char *value)
         return false;
     }
     return qstrcmp(p, value) == 0;
+}
+
+QString UdevDevice::action() const
+{
+    return QString::fromLocal8Bit(udev_device_get_action(m_device));
 }
 
 UdevMonitor::UdevMonitor(Udev *udev)

--- a/udev.h
+++ b/udev.h
@@ -9,6 +9,9 @@
 #include <memory>
 #include <kwin_export.h>
 
+#include <vector>
+#include <QVector>
+
 struct udev;
 struct udev_device;
 struct udev_monitor;
@@ -28,6 +31,7 @@ public:
     int sysNum() const;
     const char *property(const char *key);
     bool hasProperty(const char *key, const char *value);
+    QString action() const;
 
     operator udev_device*() const {
         return m_device;
@@ -68,8 +72,8 @@ public:
     bool isValid() const {
         return m_udev != nullptr;
     }
-    UdevDevice::Ptr primaryGpu();
-    UdevDevice::Ptr primaryFramebuffer();
+    std::vector<UdevDevice::Ptr> listGPUs();
+    std::vector<UdevDevice::Ptr> listFramebuffers();
     UdevDevice::Ptr deviceFromSyspath(const char *syspath);
     UdevMonitor *monitor();
     operator udev*() const {


### PR DESCRIPTION
in order to support the displaylink device and the multi GPU function, the displaylink output image buffer is use gbm_surface_create on card0, in presentOnOutput, mapped gbm_bo to user memory space, memcpy to DrmDumbBuffer and use framebuffer upper screen display.

Log:
Task: https://pms.uniontech.com/task-view-214429.html