### PR TITLE
fix: deepin-wm-dbus missing install dir

### DIFF
--- a/deepin-wm-dbus/com.deepin.wm.service.in
+++ b/deepin-wm-dbus/com.deepin.wm.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.wm
-Exec=${TARGET_PATH}/${TARGET_NAME}
+Exec=${CMAKE_INSTALL_BINDIR}/${TARGET_NAME}


### PR DESCRIPTION
missing install dir
