### PR TITLE
Optimize/scissor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ if (epoxy_HAS_GLX)
     endif()
 endif()
 
-find_package(Wayland 1.2 OPTIONAL_COMPONENTS Egl)
+find_package(Wayland 1.2 OPTIONAL_COMPONENTS Egl Server)
 set_package_properties(Wayland PROPERTIES
     TYPE REQUIRED
     PURPOSE "Required for building KWin with Wayland support"

--- a/src/effects/scissorwindow/CMakeLists.txt
+++ b/src/effects/scissorwindow/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(scissorwindow_SOURCES
     main.cpp
     scissorwindow.cpp
+    scissor.qrc
 )
 
 kwin4_add_effect_module(kwin4_effect_scissorwindow ${scissorwindow_SOURCES})

--- a/src/effects/scissorwindow/fillet.frag
+++ b/src/effects/scissorwindow/fillet.frag
@@ -1,0 +1,41 @@
+#version 300 es
+precision highp float;
+
+uniform sampler2D sampler, msk1;
+uniform sampler2D modulation;
+uniform float saturation;
+uniform vec2 k;
+uniform int typ1, typ2;
+
+in vec2 texcoord0;
+out vec4 fragColor;
+
+void main() {
+  vec4 c = texture(sampler, texcoord0);
+  if (typ1 == 1) {
+    if (typ2 == 1) {
+      vec2 tc = texcoord0 * k;
+      vec4 m0 = texture(msk1, tc);
+      tc = texcoord0 * k - vec2(0, k.t - 1.0);
+      tc.t = 1.0 - tc.t;
+      vec4 m1 = texture(msk1, tc);
+      tc = texcoord0 * k - vec2(k.s - 1.0, 0);
+      tc.s = 1.0 - tc.s;
+      vec4 m2 = texture(msk1, tc);
+      tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+      vec4 m3 = texture(msk1, tc);
+      c *= (m0.a * m1.a * m2.a * m3.a);
+    } else {
+      if (texcoord0.t > 0.5) {
+          vec2 tc = texcoord0 * k - vec2(0, k.t - 1.0);
+          tc.t = 1.0 - tc.t;
+          vec4 m1 = texture(msk1, tc);
+          tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+          vec4 m3 = texture(msk1, tc);
+          c *= (m1.a * m3.a);
+      }
+    }
+  }
+
+  fragColor = c;
+}

--- a/src/effects/scissorwindow/fillet.frag
+++ b/src/effects/scissorwindow/fillet.frag
@@ -11,31 +11,33 @@ in vec2 texcoord0;
 out vec4 fragColor;
 
 void main() {
-  vec4 c = texture(sampler, texcoord0);
-  if (typ1 == 1) {
-    if (typ2 == 1) {
-      vec2 tc = texcoord0 * k;
-      vec4 m0 = texture(msk1, tc);
-      tc = texcoord0 * k - vec2(0, k.t - 1.0);
-      tc.t = 1.0 - tc.t;
-      vec4 m1 = texture(msk1, tc);
-      tc = texcoord0 * k - vec2(k.s - 1.0, 0);
-      tc.s = 1.0 - tc.s;
-      vec4 m2 = texture(msk1, tc);
-      tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
-      vec4 m3 = texture(msk1, tc);
-      c *= (m0.a * m1.a * m2.a * m3.a);
-    } else {
-      if (texcoord0.t > 0.5) {
-          vec2 tc = texcoord0 * k - vec2(0, k.t - 1.0);
-          tc.t = 1.0 - tc.t;
-          vec4 m1 = texture(msk1, tc);
-          tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
-          vec4 m3 = texture(msk1, tc);
-          c *= (m1.a * m3.a);
-      }
+    vec4 c = texture(sampler, texcoord0);
+    if (typ1 == 1) {
+        if (typ2 == 1) {
+            vec2 tc = texcoord0 * k;
+            vec4 m0 = texture(msk1, tc);
+            tc = texcoord0 * k - vec2(0, k.t - 1.0);
+            tc.t = 1.0 - tc.t;
+            vec4 m1 = texture(msk1, tc);
+            tc = texcoord0 * k - vec2(k.s - 1.0, 0);
+            tc.s = 1.0 - tc.s;
+            vec4 m2 = texture(msk1, tc);
+            tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+            vec4 m3 = texture(msk1, tc);
+            c *= (m0.a * m1.a * m2.a * m3.a);
+        } else {
+            if (texcoord0.t > 0.5) {
+                vec2 tc = texcoord0 * k - vec2(0, k.t - 1.0);
+                tc.t = 1.0 - tc.t;
+                vec4 m1 = texture(msk1, tc);
+                tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+                vec4 m3 = texture(msk1, tc);
+                c *= (m1.a * m3.a);
+            }
+        }
     }
-  }
 
-  fragColor = c;
+    fragColor = c;
 }
+
+// vim: set ft=glsl:

--- a/src/effects/scissorwindow/fillet_core.frag
+++ b/src/effects/scissorwindow/fillet_core.frag
@@ -1,0 +1,40 @@
+#version 140
+
+uniform sampler2D sampler, msk1;
+uniform sampler2D modulation;
+uniform float saturation;
+uniform vec2 k;
+uniform int typ1, typ2;
+
+in vec2 texcoord0;
+out vec4 fragColor;
+
+void main() {
+  vec4 c = texture(sampler, texcoord0);
+  if (typ1 == 1) {
+    if (typ2 == 1) {
+      vec2 tc = texcoord0 * k;
+      vec4 m0 = texture(msk1, tc);
+      tc = texcoord0 * k - vec2(0, k.t - 1.0);
+      tc.t = 1.0 - tc.t;
+      vec4 m1 = texture(msk1, tc);
+      tc = texcoord0 * k - vec2(k.s - 1.0, 0);
+      tc.s = 1.0 - tc.s;
+      vec4 m2 = texture(msk1, tc);
+      tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+      vec4 m3 = texture(msk1, tc);
+      c *= (m0.a * m1.a * m2.a * m3.a);
+    } else {
+      if (texcoord0.t > 0.5) {
+          vec2 tc = texcoord0 * k - vec2(0, k.t - 1.0);
+          tc.t = 1.0 - tc.t;
+          vec4 m1 = texture(msk1, tc);
+          tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+          vec4 m3 = texture(msk1, tc);
+          c *= (m1.a * m3.a);
+      }
+    }
+  }
+
+  fragColor = c;
+}

--- a/src/effects/scissorwindow/fillet_core.frag
+++ b/src/effects/scissorwindow/fillet_core.frag
@@ -10,31 +10,33 @@ in vec2 texcoord0;
 out vec4 fragColor;
 
 void main() {
-  vec4 c = texture(sampler, texcoord0);
-  if (typ1 == 1) {
-    if (typ2 == 1) {
-      vec2 tc = texcoord0 * k;
-      vec4 m0 = texture(msk1, tc);
-      tc = texcoord0 * k - vec2(0, k.t - 1.0);
-      tc.t = 1.0 - tc.t;
-      vec4 m1 = texture(msk1, tc);
-      tc = texcoord0 * k - vec2(k.s - 1.0, 0);
-      tc.s = 1.0 - tc.s;
-      vec4 m2 = texture(msk1, tc);
-      tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
-      vec4 m3 = texture(msk1, tc);
-      c *= (m0.a * m1.a * m2.a * m3.a);
-    } else {
-      if (texcoord0.t > 0.5) {
-          vec2 tc = texcoord0 * k - vec2(0, k.t - 1.0);
-          tc.t = 1.0 - tc.t;
-          vec4 m1 = texture(msk1, tc);
-          tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
-          vec4 m3 = texture(msk1, tc);
-          c *= (m1.a * m3.a);
-      }
+    vec4 c = texture(sampler, texcoord0);
+    if (typ1 == 1) {
+        if (typ2 == 1) {
+            vec2 tc = texcoord0 * k;
+            vec4 m0 = texture(msk1, tc);
+            tc = texcoord0 * k - vec2(0, k.t - 1.0);
+            tc.t = 1.0 - tc.t;
+            vec4 m1 = texture(msk1, tc);
+            tc = texcoord0 * k - vec2(k.s - 1.0, 0);
+            tc.s = 1.0 - tc.s;
+            vec4 m2 = texture(msk1, tc);
+            tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+            vec4 m3 = texture(msk1, tc);
+            c *= (m0.a * m1.a * m2.a * m3.a);
+        } else {
+            if (texcoord0.t > 0.5) {
+                vec2 tc = texcoord0 * k - vec2(0, k.t - 1.0);
+                tc.t = 1.0 - tc.t;
+                vec4 m1 = texture(msk1, tc);
+                tc = 1.0 - ((texcoord0 - 1.0) * k + 1.0);
+                vec4 m3 = texture(msk1, tc);
+                c *= (m1.a * m3.a);
+            }
+        }
     }
-  }
 
-  fragColor = c;
+    fragColor = c;
 }
+
+// vim: set ft=glsl:

--- a/src/effects/scissorwindow/mask.frag
+++ b/src/effects/scissorwindow/mask.frag
@@ -1,0 +1,14 @@
+#version 300 es
+precision highp float;
+
+uniform sampler2D sampler, msk1;
+
+in vec2 texcoord0;
+out vec4 fragColor;
+
+void main() {
+  vec4 c = texture(sampler, texcoord0);
+  vec4 m = texture(msk1, texcoord0);
+  c *= m.a;
+  fragColor = c;
+}

--- a/src/effects/scissorwindow/mask.frag
+++ b/src/effects/scissorwindow/mask.frag
@@ -7,8 +7,10 @@ in vec2 texcoord0;
 out vec4 fragColor;
 
 void main() {
-  vec4 c = texture(sampler, texcoord0);
-  vec4 m = texture(msk1, texcoord0);
-  c *= m.a;
-  fragColor = c;
+    vec4 c = texture(sampler, texcoord0);
+    vec4 m = texture(msk1, texcoord0);
+    c *= m.a;
+    fragColor = c;
 }
+
+// vim: set ft=glsl:

--- a/src/effects/scissorwindow/mask_core.frag
+++ b/src/effects/scissorwindow/mask_core.frag
@@ -1,0 +1,13 @@
+#version 140
+
+uniform sampler2D sampler, msk1;
+
+in vec2 texcoord0;
+out vec4 fragColor;
+
+void main() {
+  vec4 c = texture(sampler, texcoord0);
+  vec4 m = texture(msk1, texcoord0);
+  c *= m.a;
+  fragColor = c;
+}

--- a/src/effects/scissorwindow/mask_core.frag
+++ b/src/effects/scissorwindow/mask_core.frag
@@ -6,8 +6,10 @@ in vec2 texcoord0;
 out vec4 fragColor;
 
 void main() {
-  vec4 c = texture(sampler, texcoord0);
-  vec4 m = texture(msk1, texcoord0);
-  c *= m.a;
-  fragColor = c;
+    vec4 c = texture(sampler, texcoord0);
+    vec4 m = texture(msk1, texcoord0);
+    c *= m.a;
+    fragColor = c;
 }
+
+// vim: set ft=glsl:

--- a/src/effects/scissorwindow/scissor.qrc
+++ b/src/effects/scissorwindow/scissor.qrc
@@ -1,0 +1,9 @@
+<!DOCTYPE RCC>
+<RCC version="1.0">
+    <qresource prefix="/effects/scissor">
+        <file>fillet_core.frag</file>
+        <file>fillet.frag</file>
+        <file>mask_core.frag</file>
+        <file>mask.frag</file>
+    </qresource>
+</RCC>

--- a/src/effects/scissorwindow/scissorwindow.cpp
+++ b/src/effects/scissorwindow/scissorwindow.cpp
@@ -257,12 +257,6 @@ void ScissorWindow::windowAdded(EffectWindow *w) {
 
 void ScissorWindow::windowDeleted(EffectWindow *w) {
     m_clipMaskMap.erase(w);
-
-    const QVariant &data_clip_path = w->data(WindowClipPathRole);
-    if (data_clip_path.isValid()) {
-        // FIXME: The reason for redrawing is that there are false shadows in the window of the clip path, and the screen needs to be forcibly updated.
-        effects->addRepaintFull();
-    }
 }
 
 bool ScissorWindow::isMaximized(EffectWindow *w) {

--- a/src/effects/scissorwindow/scissorwindow.cpp
+++ b/src/effects/scissorwindow/scissorwindow.cpp
@@ -119,7 +119,7 @@ void ScissorWindow::drawWindow(EffectWindow *w, int mask, const QRegion& region,
         || isMaximized(w)
         || (mask & (PAINT_SCREEN_WITH_TRANSFORMED_WINDOWS)))
     {
-        effects->paintWindow(w, mask, region, data);
+        effects->drawWindow(w, mask, region, data);
         return;
     }
 
@@ -167,7 +167,7 @@ void ScissorWindow::drawWindow(EffectWindow *w, int mask, const QRegion& region,
             glActiveTexture(GL_TEXTURE2); maskTexture->bind();
 
             glActiveTexture(GL_TEXTURE0);
-            effects->paintWindow(w, mask, region, data);
+            effects->drawWindow(w, mask, region, data);
 
             ShaderManager::instance()->popShader();
             data.shader = old_shader;
@@ -198,7 +198,7 @@ void ScissorWindow::drawWindow(EffectWindow *w, int mask, const QRegion& region,
             }
         }
         if (cornerRadius < 2) {
-            effects->paintWindow(w, mask, region, data);
+            effects->drawWindow(w, mask, region, data);
             return;
         }
 
@@ -234,7 +234,7 @@ void ScissorWindow::drawWindow(EffectWindow *w, int mask, const QRegion& region,
         glActiveTexture(GL_TEXTURE1);
         m_texMaskMap[cornerRadius]->bind();
         glActiveTexture(GL_TEXTURE0);
-        effects->paintWindow(w, mask, region, data);
+        effects->drawWindow(w, mask, region, data);
         ShaderManager::instance()->popShader();
         data.shader = old_shader;
         glActiveTexture(GL_TEXTURE1);

--- a/src/effects/scissorwindow/scissorwindow.h
+++ b/src/effects/scissorwindow/scissorwindow.h
@@ -22,7 +22,6 @@ class ScissorWindow : public Effect
     struct WindowMaskCache {
         QPainterPath maskPath;
         std::shared_ptr<GLTexture> maskTexture;
-        std::shared_ptr<GLTexture> borderTexture;
     };
 
 public:
@@ -53,7 +52,7 @@ public:
 
     void prePaintWindow(EffectWindow* w, WindowPrePaintData& data, std::chrono::milliseconds time) override;
 
-    void paintWindow(EffectWindow* w, int mask, QRegion region, WindowPaintData& data) override;
+    void drawWindow(EffectWindow* w, int mask, const QRegion& region, WindowPaintData& data) override;
 
 protected Q_SLOTS:
     void windowAdded(EffectWindow *window);
@@ -66,7 +65,7 @@ private:
 
     GLTexture *m_texMask[NCorners];
     //GLTexture *m_maskTexture;
-    GLShader *m_shader, *m_shader1, *m_shader2, *m_shader3;
+    GLShader *m_shader, *m_maskShader, *m_filletOptimizeShader;
     std::map<int, GLTexture*> m_texMaskMap;
     std::map<EffectWindow*, WindowMaskCache> m_clipMaskMap;
 };

--- a/src/effects/scissorwindow/scissorwindow.h
+++ b/src/effects/scissorwindow/scissorwindow.h
@@ -5,7 +5,11 @@
 #define SCISSORWINDOW_H
 
 #include <deepin_kwineffects.h>
+
+#include <QPainterPath>
+
 #include <map>
+#include <memory>
 
 namespace KWin { class GLTexture; }
 
@@ -14,6 +18,12 @@ namespace KWin {
 class ScissorWindow : public Effect
 {
     Q_OBJECT
+
+    struct WindowMaskCache {
+        QPainterPath maskPath;
+        std::shared_ptr<GLTexture> maskTexture;
+        std::shared_ptr<GLTexture> borderTexture;
+    };
 
 public:
     ScissorWindow();
@@ -47,6 +57,7 @@ public:
 
 protected Q_SLOTS:
     void windowAdded(EffectWindow *window);
+    void windowDeleted(EffectWindow *window);
 
 private:
     enum { TopLeft = 0, TopRight, BottomRight, BottomLeft, NCorners };
@@ -57,6 +68,7 @@ private:
     //GLTexture *m_maskTexture;
     GLShader *m_shader, *m_shader1, *m_shader2, *m_shader3;
     std::map<int, GLTexture*> m_texMaskMap;
+    std::map<EffectWindow*, WindowMaskCache> m_clipMaskMap;
 };
 
 }

--- a/src/effects/scissorwindow/scissorwindow.h
+++ b/src/effects/scissorwindow/scissorwindow.h
@@ -65,7 +65,7 @@ private:
 
     GLTexture *m_texMask[NCorners];
     //GLTexture *m_maskTexture;
-    GLShader *m_shader, *m_maskShader, *m_filletOptimizeShader;
+    GLShader *m_maskShader, *m_filletOptimizeShader;
     std::map<int, GLTexture*> m_texMaskMap;
     std::map<EffectWindow*, WindowMaskCache> m_clipMaskMap;
 };

--- a/src/plugins/kdecorations/deepin-chameleon/chameleon.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleon.cpp
@@ -603,16 +603,6 @@ void Chameleon::updateShadow()
 {
     if (m_config && settings()->isAlphaChannelSupported()) {
         if (m_theme->validProperties() == ChameleonWindowTheme::PropertyFlags()) {
-            const QVariant &data_clip_path = effect()->data(ChameleonConfig::WindowClipPathRole);
-            if (data_clip_path.isValid()) {
-                return;
-            }
-
-            { /* set shadow image for scissor effect */
-                auto shadow1 = ChameleonShadow::instance()->getShadow(m_config, m_theme->windowPixelRatio());
-                effect()->setData(ChameleonConfig::ShadowMaskRole, QVariant(shadow1->shadow()));
-                effect()->setData(ChameleonConfig::ShadowOffsetRole, QVariant(shadow1->paddingTop()));
-	    }
             return setShadow(ChameleonShadow::instance()->getShadow(m_config, m_theme->windowPixelRatio()));
         }
 
@@ -644,18 +634,7 @@ void Chameleon::updateShadow()
             m_config->shadowConfig.shadowColor = m_theme->shadowColor();
         }
 
-        const QVariant &data_clip_path = effect()->data(ChameleonConfig::WindowClipPathRole);
-        if (data_clip_path.isValid()) {
-            return;
-        }
-
         setShadow(ChameleonShadow::instance()->getShadow(m_config, scale));
-
-        { /* set shadow image for scissor effect */
-            auto shadow1 = ChameleonShadow::instance()->getShadow(m_config, scale);
-            effect()->setData(ChameleonConfig::ShadowMaskRole, QVariant(shadow1->shadow()));
-            effect()->setData(ChameleonConfig::ShadowOffsetRole, QVariant(shadow1->paddingTop()));
-        }
     }
 }
 


### PR DESCRIPTION
优化前：
![telegram-cloud-photo-size-5-6152251007971734651-y](https://user-images.githubusercontent.com/12298476/229808528-9716f8eb-bf64-4da5-bd51-9089eff3a6b3.jpg)


优化后：
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/12298476/229808417-64334342-2619-4fc8-a7a9-a7e9ee1f2a24.png">

还有一个剩余问题，clip path 的窗口存在一个自绘阴影，这个阴影的操作有点消耗gpu，尽管已经有了缓存，但是首次执行仍然可以用到 70%以上的gpu，可以考虑增加一个设置项，控制一下阴影的质量，以及如果窗口设置了 transparent 的阴影颜色，就放弃阴影处理。