### PR TITLE
fix: not install config files into GenericConfigLocation

### DIFF
--- a/configures/CMakeLists.txt
+++ b/configures/CMakeLists.txt
@@ -6,7 +6,7 @@ install(
         deepin-klaunchrc
         deepin-kdeglobals
     DESTINATION
-        ${CMAKE_INSTALL_SYSCONFDIR}
+        ${KDE_INSTALL_CONFDIR}
 )
 
 install(

--- a/debian/deepin-kwin-data.install
+++ b/debian/deepin-kwin-data.install
@@ -28,9 +28,9 @@ usr/share/kservicetypes5/deepin-kwin*.desktop
 usr/share/deepin-kwin/
 usr/share/locale/
 usr/share/qlogging-categories5/
-etc/deepin-kdeglobals
-etc/deepin-kglobalshortcutsrc
-etc/deepin-klaunchrc
-etc/deepin-kwinrc
-etc/deepin-kwinrulesrc
+etc/xdg/deepin-kdeglobals
+etc/xdg/deepin-kglobalshortcutsrc
+etc/xdg/deepin-klaunchrc
+etc/xdg/deepin-kwinrc
+etc/xdg/deepin-kwinrulesrc
 usr/share/dsg/configs/org.deepin.kwin/org.deepin.kwin.splitmenu.display.json


### PR DESCRIPTION
KConfig::openConfig will search files in GenericConfigLocation