### PR TITLE
fix: cannot use super to launch dde-launcher on wayland mode

### DIFF
--- a/configures/deepin-kwinrc
+++ b/configures/deepin-kwinrc
@@ -101,4 +101,4 @@ CommandAll3=Nothing
 
 # for wayland platform
 [ModifierOnlyShortcuts]
-Meta=com.deepin.dde.Launcher,/com/deepin/dde/Launcher,com.deepin.dde.Launcher,Toggle
+Meta=org.deepin.dde.Launcher1,/org/deepin/dde/Launcher1,org.deepin.dde.Launcher1,Toggle


### PR DESCRIPTION
dde-launcher dbus service not working.
