### PR TITLE
fix: ensure the shadow item after stack of the window

### DIFF
--- a/src/windowitem.cpp
+++ b/src/windowitem.cpp
@@ -99,7 +99,9 @@ void WindowItem::updateShadowItem()
         if (m_decorationItem) {
             m_shadowItem->stackBefore(m_decorationItem.data());
         } else if (m_surfaceItem) {
-            m_shadowItem->stackBefore(m_decorationItem.data());
+            m_shadowItem->stackBefore(m_surfaceItem.data());
+        } else {
+            m_shadowItem->stackAfter(this);
         }
     } else {
         m_shadowItem.reset();


### PR DESCRIPTION
For the no decoration windows, we can using _KDE_NET_WM_SHADOW to render shadows for it, the shadow item needs after stack of the window to avoid mask window.