### PR TITLE
fix: All windows share a theme

### DIFF
--- a/src/plugins/kdecorations/deepin-chameleon/chameleon.h
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleon.h
@@ -31,7 +31,6 @@ public:
 
     void paint(QPainter *painter, const QRect &repaintArea) override;
 
-    const ChameleonTheme::ThemeConfig *themeConfig() const;
     KWin::EffectWindow *effect() const;
     bool noTitleBar() const;
 
@@ -100,8 +99,8 @@ private:
 
     QMarginsF m_titleBarAreaMargins;
     QPainterPath m_borderPath;
-    ChameleonTheme::ConfigGroup* m_configGroup = nullptr;
-    ChameleonTheme::ThemeConfig *m_config = nullptr;
+    ChameleonTheme::ConfigGroup* m_baseConfigGroup = nullptr;
+    ChameleonTheme::ThemeConfig m_config;
     ChameleonWindowTheme *m_theme = nullptr;
 
     QString m_title;

--- a/src/plugins/kdecorations/deepin-chameleon/chameleonconfig.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonconfig.cpp
@@ -1187,13 +1187,13 @@ void ChameleonConfig::buildKWinX11Shadow(QObject *window)
         theme_config.borderConfig.borderWidth = 0;
     }
 
-    const QString &shadow_key = ChameleonShadow::buildShadowCacheKey(&theme_config, scale);
+    const QString &shadow_key = ChameleonShadow::buildShadowCacheKey(theme_config, scale);
     X11Shadow *shadow = m_x11ShadowCache.value(shadow_key);
 
     //if (!shadow && QX11Info::isPlatformX11()) {
     if (QX11Info::isPlatformX11()) {
 
-        auto s = ChameleonShadow::instance()->getShadow(&theme_config, scale);
+        auto s = ChameleonShadow::instance()->getShadow(theme_config, scale);
 
         {
             KWin::EffectWindow *effect = nullptr;

--- a/src/plugins/kdecorations/deepin-chameleon/chameleonshadow.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonshadow.cpp
@@ -17,14 +17,14 @@ ChameleonShadow *ChameleonShadow::instance()
     return _global_cs;
 }
 
-QString ChameleonShadow::buildShadowCacheKey(const ChameleonTheme::ThemeConfig *config, qreal scale)
+QString ChameleonShadow::buildShadowCacheKey(const ChameleonTheme::ThemeConfig &config, qreal scale)
 {
-    auto window_radius = config->radius * scale;
-    auto shadow_offset = config->shadowConfig.shadowOffset;
-    QColor shadow_color = config->shadowConfig.shadowColor;
-    int shadow_size = config->shadowConfig.shadowRadius;
-    qreal border_width = config->borderConfig.borderWidth;
-    QColor border_color = config->borderConfig.borderColor;
+    auto window_radius = config.radius * scale;
+    auto shadow_offset = config.shadowConfig.shadowOffset;
+    QColor shadow_color = config.shadowConfig.shadowColor;
+    int shadow_size = config.shadowConfig.shadowRadius;
+    qreal border_width = config.borderConfig.borderWidth;
+    QColor border_color = config.borderConfig.borderColor;
 
     const QPointF shadow_overlap(qMax(window_radius.x(), 3.0), qMax(window_radius.y(), 3.0));
     const QMargins &paddings = QMargins(shadow_size - shadow_offset.x() - shadow_overlap.x(),
@@ -38,23 +38,23 @@ QString ChameleonShadow::buildShadowCacheKey(const ChameleonTheme::ThemeConfig *
                                                 .arg(border_width).arg(border_color.name());
 }
 
-QSharedPointer<KDecoration2::DecorationShadow> ChameleonShadow::getShadow(const ChameleonTheme::ThemeConfig *config, qreal scale)
+QSharedPointer<KDecoration2::DecorationShadow> ChameleonShadow::getShadow(const ChameleonTheme::ThemeConfig &config, qreal scale)
 {
-    if ((config->shadowConfig.shadowColor.alpha() == 0 || qIsNull(config->shadowConfig.shadowRadius))
-            && (config->borderConfig.borderColor.alpha() == 0 || qIsNull(config->borderConfig.borderWidth))) {
+    if ((config.shadowConfig.shadowColor.alpha() == 0 || qIsNull(config.shadowConfig.shadowRadius))
+            && (config.borderConfig.borderColor.alpha() == 0 || qIsNull(config.borderConfig.borderWidth))) {
         return m_emptyShadow;
     }
 
-    bool no_shadow = config->shadowConfig.shadowColor.alpha() == 0 || qIsNull(config->shadowConfig.shadowRadius);
+    bool no_shadow = config.shadowConfig.shadowColor.alpha() == 0 || qIsNull(config.shadowConfig.shadowRadius);
 
-    auto window_radius = config->radius * scale;
-    auto shadow_offset = config->shadowConfig.shadowOffset;
-    QColor shadow_color = config->shadowConfig.shadowColor;
+    auto window_radius = config.radius * scale;
+    auto shadow_offset = config.shadowConfig.shadowOffset;
+    QColor shadow_color = config.shadowConfig.shadowColor;
     // 因为阴影区域会抹除窗口圆角区域，所以阴影大小需要额外加上窗口圆角大小
-    int shadow_size = config->shadowConfig.shadowRadius + window_radius.x() + window_radius.y();
+    int shadow_size = config.shadowConfig.shadowRadius + window_radius.x() + window_radius.y();
 
-    qreal border_width = config->borderConfig.borderWidth;
-    QColor border_color = config->borderConfig.borderColor;
+    qreal border_width = config.borderConfig.borderWidth;
+    QColor border_color = config.borderConfig.borderColor;
 
     const QPointF shadow_overlap(qMax(window_radius.x(), 3.0), qMax(window_radius.y(), 3.0));
     const QMargins &paddings = QMargins(shadow_size - shadow_offset.x() - shadow_overlap.x(),

--- a/src/plugins/kdecorations/deepin-chameleon/chameleonshadow.h
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonshadow.h
@@ -15,8 +15,8 @@ class ChameleonShadow
 public:
     static ChameleonShadow *instance();
 
-    static QString buildShadowCacheKey(const ChameleonTheme::ThemeConfig *config, qreal scale);
-    QSharedPointer<KDecoration2::DecorationShadow> getShadow(const ChameleonTheme::ThemeConfig *config, qreal scale);
+    static QString buildShadowCacheKey(const ChameleonTheme::ThemeConfig &config, qreal scale);
+    QSharedPointer<KDecoration2::DecorationShadow> getShadow(const ChameleonTheme::ThemeConfig &config, qreal scale);
 
     void clearCache();
 


### PR DESCRIPTION
If no specific value is obtained from the window,
the default theme configuration will fall back to use, but the default theme configuration is a pointer,
which causes all windows to share the same configuration.