### PR TITLE
fix: DPMS off seems to blank compositor's back or front buffer

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -94,6 +94,7 @@ Build-Depends: breeze-dev (>= 4:5.24.2~),
                wayland-protocols (>= 1.19~),
                libxcb-util0-dev,
                libxtst-dev,
+               libxss-dev,
 Standards-Version: 4.6.0
 Homepage: https://projects.kde.org/projects/kde/workspace/kwin
 Vcs-Browser: https://salsa.debian.org/qt-kde-team/kde/kwin

--- a/src/backends/x11/standalone/CMakeLists.txt
+++ b/src/backends/x11/standalone/CMakeLists.txt
@@ -17,7 +17,7 @@ set(X11PLATFORM_SOURCES
 
 add_library(KWinX11Platform MODULE ${X11PLATFORM_SOURCES})
 set_target_properties(KWinX11Platform PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/org.kde.deepin-kwin.platforms/")
-target_link_libraries(KWinX11Platform eglx11common deepin-kwin deepin-kwinxrenderutils Qt::X11Extras KF5::Crash X11::X11)
+target_link_libraries(KWinX11Platform eglx11common deepin-kwin deepin-kwinxrenderutils Qt::X11Extras KF5::Crash X11::X11 X11::Xss)
 if (X11_Xi_FOUND)
     target_sources(KWinX11Platform PRIVATE xinputintegration.cpp)
     target_link_libraries(KWinX11Platform X11::Xi)

--- a/src/backends/x11/standalone/glxbackend.h
+++ b/src/backends/x11/standalone/glxbackend.h
@@ -60,6 +60,16 @@ private:
     xcb_glx_drawable_t m_glxDrawable;
 };
 
+class GlxBackend;
+class DpmsEventFilter : public X11EventFilter
+{
+public:
+    DpmsEventFilter(int eventCode, GlxBackend *backend);
+    bool event(xcb_generic_event_t *event) override;
+
+private:
+    GlxBackend *m_backend;
+};
 
 /**
  * @brief OpenGL Backend using GLX over an X overlay window.
@@ -80,6 +90,9 @@ public:
     void init() override;
 
     Display *display() const { return m_x11Display; }
+
+Q_SIGNALS:
+    void dpmsStateChanged(bool on);
 
 private:
     void vblank(std::chrono::nanoseconds timestamp);
@@ -107,8 +120,10 @@ private:
     QHash<xcb_visualid_t, FBConfigInfo *> m_fbconfigHash;
     QHash<xcb_visualid_t, int> m_visualDepthHash;
     std::unique_ptr<SwapEventFilter> m_swapEventFilter;
+    std::unique_ptr<DpmsEventFilter> m_dpmsEventFilter;
     DamageJournal m_damageJournal;
     int m_bufferAge;
+    int m_forceFullRepaintCount = 0;
     bool m_haveMESACopySubBuffer = false;
     bool m_haveMESASwapControl = false;
     bool m_haveEXTSwapControl = false;


### PR DESCRIPTION
The GLX_EXT_buffer_age allow extension is to expose enough information to applications about how the driver manages the set of front and back buffers associated with a given surface to allow applications to re-use the contents of old frames and minimize how much must be redrawn for the next frame.

If using GLX_EXT_buffer_age on kwin, it's using the repaint area from the damage areas to do partial refresh in compositor. when dpms off and dpms on soon(The interval of one second may be repeated), you will see the screen is flash with the some part of black in some frame, maybe one buffer of front buffer and back buffer is broke, and kwin only draw a part of the buffer, so the other part of the buffer is black.

Upstream bug: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1296
Issue: https://github.com/linuxdeepin/developer-center/issues/4252