### PR TITLE
chore: Pick the best fillet

### DIFF
--- a/src/effects/blur/blur.cpp
+++ b/src/effects/blur/blur.cpp
@@ -652,8 +652,12 @@ void BlurEffect::drawWindow(EffectWindow *w, int mask, const QRegion &region, Wi
                     valueRadius.toPointF().y() > 2)
                 {
                     QPointF cornerRadius = w->data(WindowRadiusRole).toPointF();
-                    cornerRadius = QPointF(std::min(cornerRadius.x(), w->width() / 2.0),
-                                           std::min(cornerRadius.y(), w->height() / 2.0));
+                    const qreal xMin{ std::min(cornerRadius.x(),
+                                               w->width() / 2.0) };
+                    const qreal yMin{ std::min(cornerRadius.y(),
+                                               w->height() / 2.0) };
+                    const qreal minRadius{ std::min(xMin, yMin) };
+                    cornerRadius = QPointF(minRadius, minRadius);
                     shape = rounded(shape, cornerRadius);
                 }
                 doBlur(shape, screen, data.opacity(), data.screenProjectionMatrix(), w->isDock() || transientForIsDock, w->frameGeometry());

--- a/src/effects/scissorwindow/scissorwindow.cpp
+++ b/src/effects/scissorwindow/scissorwindow.cpp
@@ -164,8 +164,10 @@ void ScissorWindow::drawWindow(EffectWindow *w, int mask, const QRegion& region,
         const QVariant valueRadius = w->data(WindowRadiusRole);
         if (valueRadius.isValid()) {
             cornerRadius = w->data(WindowRadiusRole).toPointF();
-            cornerRadius = QPointF(std::min(cornerRadius.x(), w->width() / 2.0),
-                                   std::min(cornerRadius.y(), w->height() / 2.0));
+            const qreal xMin{ std::min(cornerRadius.x(), w->width() / 2.0) };
+            const qreal yMin{ std::min(cornerRadius.y(), w->height() / 2.0) };
+            const qreal minRadius{ std::min(xMin, yMin) };
+            cornerRadius = QPointF(minRadius, minRadius);
         } else {
             if (!(w->isDesktop() || w->isDock())) {
                 EffectsHandlerImpl *effs = static_cast<EffectsHandlerImpl *>(effects);

--- a/src/plugins/kdecorations/deepin-chameleon/chameleonconfig.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonconfig.cpp
@@ -594,9 +594,6 @@ void ChameleonConfig::updateClientWindowRadius(QObject *client)
         }
     }
 
-    // NOTE: 窗口圆角的范围不得超过高度的一半，否则会产生视觉错误。
-    window_radius = QPointF(std::min(window_radius.x(), effect->height() / 2.0), std::min(window_radius.y(), effect->height() / 2.0));
-
     const QVariant &effect_window_radius = effect->data(ChameleonConfig::WindowRadiusRole);
     bool need_update = true;
 

--- a/src/plugins/kdecorations/deepin-chameleon/chameleonshadow.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonshadow.cpp
@@ -49,8 +49,10 @@ QSharedPointer<KDecoration2::DecorationShadow> ChameleonShadow::getShadow(const 
 
     auto window_radius = config.radius * scale;
     if (!config.radius.isNull() && !maxWindowRadius.isNull()) {
-        window_radius = QPointF(std::min(window_radius.x(), maxWindowRadius.x()),
-                                std::min(window_radius.y(), maxWindowRadius.y()));
+        const qreal xMin{ std::min(window_radius.x(), maxWindowRadius.x()) };
+        const qreal yMin{ std::min(window_radius.y(), maxWindowRadius.y()) };
+        const qreal minRadius{ std::min(xMin, yMin) };
+        window_radius = QPointF(minRadius, minRadius);
     }
 
     auto shadow_offset = config.shadowConfig.shadowOffset;


### PR DESCRIPTION
Get the minimum available rounded corners on x and y, and calculate the smallest available again, which can make the rounded corners appear rectangular.

Closed: https://github.com/linuxdeepin/developer-center/issues/4223