### PR TITLE
fix: button disappeared when using custom config; dialog title font color in dark mode

### DIFF
--- a/src/plugins/kdecorations/deepin-chameleon/chameleontheme.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleontheme.cpp
@@ -335,8 +335,7 @@ static void writeConfig(const UIWindowType& windowType, const QJsonValue& window
             const auto& it = base->managedConfigGroupMap.find(windowType);
             base_active = &(it->normal);
             base_inactive = &(it->inactive);
-        }
-        if (base->unmanagedConfigMap.contains(windowType)) {
+        } else if (base->unmanagedConfigMap.contains(windowType)) {
             const auto& it = base->unmanagedConfigMap.find(windowType);
             base_active = &*it;
         }
@@ -349,7 +348,7 @@ static void writeConfig(const UIWindowType& windowType, const QJsonValue& window
     ChameleonTheme::ThemeConfig* config_unmanaged = &unmanagedConfig;
 
     parserWindowDecoration(windowType, windowDecoration, "active", config_active, base_active);
-    parserWindowDecoration(windowType, windowDecoration, "inactive", config_inactive, config_active);
+    parserWindowDecoration(windowType, windowDecoration, "inactive", config_inactive, base_inactive);
     parserWindowDecoration(windowType, windowDecoration, "unmanaged", config_unmanaged, config_active);
 
     configs->managedConfigGroupMap.insert(windowType, managedConfigGroup);

--- a/src/plugins/kdecorations/deepin-chameleon/deepin/dark/decoration.json
+++ b/src/plugins/kdecorations/deepin-chameleon/deepin/dark/decoration.json
@@ -114,7 +114,7 @@
       "font-family": "SourceHanSansSC",
       "font-size": 14,
       "text-align": "center",
-      "text-color": "#000000",
+      "text-color": "#BBBBBB",
       "button-group": {
         "menu": {
           "pos": "12,3",


### PR DESCRIPTION
当通过修改~/.local/share/deepin/themes/deepin/dark/decoration.json和~/.local/share/deepin/themes/deepin/light/decoration.json来自定义第三方应用标题栏高度时，会出现操作按钮消失的情况，应用本修复后则可以正常生效；另外修复了深色模式下对话框标题文字颜色为黑色看不清的问题： https://github.com/linuxdeepin/developer-center/issues/5133