### PR TITLE
fix: After using the text tube to split the screen, click the maximi…

### DIFF
--- a/src/abstract_client.cpp
+++ b/src/abstract_client.cpp
@@ -3655,7 +3655,7 @@ void AbstractClient::cancelSplitManage()
     }
 
     SplitManage::instance()->removeWinSplit(this);
-    if (!isMinimized())
+    if (!isMinimized() && !isMaximizable() )
         quitSplitStatus();
 }
 


### PR DESCRIPTION
fix : after using the text tube to split the screen, click the maximize button, the right angle of the window edge becomes a rounded corner

This means that the quitSplitStatus() function will only be executed if the window can neither be minimized (non-minimizable) nor maximized (non-maximizable). This is to ensure that in the case of a window that is not minimizeable and not maximizeable, the split is canceled and the window is restored to its normal state.

Issue: https://github.com/linuxdeepin/developer-center/issues/4956