### PR TITLE
fix: click the maximize button, the right angle of the window edge becomes rounded

### DIFF
--- a/src/abstract_client.cpp
+++ b/src/abstract_client.cpp
@@ -3655,7 +3655,7 @@ void AbstractClient::cancelSplitManage()
     }
 
     SplitManage::instance()->removeWinSplit(this);
-    if (!isMinimized())
+    if (!isMinimized() && !isMaximizable())
         quitSplitStatus();
 }
 


### PR DESCRIPTION
fix: After using the text tube to split the screen, click the maximize button, the right angle of the window edge becomes a rounded corner

This modification will only perform the unsplit operation when both conditions are met (the window cannot be minimized and cannot be maximized) to ensure the consistency of the split state.

Issue: https://github.com/linuxdeepin/developer-center/issues/4956