### PR TITLE
fix: crash when there is no active window

### DIFF
--- a/src/splitoutline.cpp
+++ b/src/splitoutline.cpp
@@ -89,6 +89,8 @@ void SplitOutline::mousePressEvent(QMouseEvent* e)
 
     // handleSplitScreenLayer();
     m_activeClient = Workspace::self()->activeClient();
+    if (!m_activeClient)
+        return;
     m_activeClientMode = m_activeClient->quickTileMode();
     m_desktop = effects->currentDesktop();//m_activeClient->desktop();
     //m_screen = m_activeClient->output()->name();


### PR DESCRIPTION
When there is no active window, splitoutline should not respond to mousePressEvent.

Log: fix crash when there is no active window