### PR TITLE
fix: incorrect radius of split menu

### DIFF
--- a/src/plugins/kdecorations/deepin-chameleon/chameleonsplitmenu.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonsplitmenu.cpp
@@ -172,37 +172,27 @@ void ChameleonSplitMenu::leaveEvent(QEvent *e)
 
 void ChameleonSplitMenu::paintEvent(QPaintEvent *e)
 {
-    QPainter painter(this);
-
-    QColor col_menu = QColor("#EEEEEE");
-    col_menu.setAlpha(255 * 0.8);
-    llabel->setGeometry(QRect(14, 14, 44, 58));
-    clabel->setGeometry(QRect(60, 14, 44, 58));
+    Q_UNUSED(e)
+    llabel->setGeometry(QRect(13, 13, 44, 58));
+    clabel->setGeometry(QRect(59, 13, 44, 58));
     if (m_isSupportFourSplit) {
-        threeLabelLeft->setGeometry(QRect(120, 14, 44, 58));
-        threeLabelTopRight->setGeometry(QRect(166, 14, 44, 28));
-        threeLabelBottomRight->setGeometry(QRect(166, 44, 44, 28));
+        threeLabelLeft->setGeometry(QRect(119, 13, 44, 58));
+        threeLabelTopRight->setGeometry(QRect(165, 13, 44, 28));
+        threeLabelBottomRight->setGeometry(QRect(165, 43, 44, 28));
 
-        threeLabelTopLeft->setGeometry(QRect(14, 88, 44, 28));
-        threeLabelBottomLeft->setGeometry(QRect(14, 118, 44, 28));
-        threeLabelRight->setGeometry(QRect(60, 88, 44, 58));
+        threeLabelTopLeft->setGeometry(QRect(13, 87, 44, 28));
+        threeLabelBottomLeft->setGeometry(QRect(13, 117, 44, 28));
+        threeLabelRight->setGeometry(QRect(59, 87, 44, 58));
 
-        fourLabelTopLeft->setGeometry(QRect(120, 88, 44, 28));
-        fourLabelBottomLeft->setGeometry(QRect(120, 118, 44, 28));
-        fourLabelTopRight->setGeometry(QRect(166, 88, 44, 28));
-        fourLabelBottomRight->setGeometry(QRect(166, 118, 44, 28));
+        fourLabelTopLeft->setGeometry(QRect(119, 87, 44, 28));
+        fourLabelBottomLeft->setGeometry(QRect(119, 117, 44, 28));
+        fourLabelTopRight->setGeometry(QRect(165, 87, 44, 28));
+        fourLabelBottomRight->setGeometry(QRect(165, 117, 44, 28));
 
-        blabel->setGeometry(QRect(0, 0, 224, 160));
+        blabel->setGeometry(QRect(0, 0, 222, 158));
     } else {
-        blabel->setGeometry(QRect(0, 0, 119, 87));
+        blabel->setGeometry(QRect(0, 0, 116, 84));
     }
-    painter.setRenderHints(QPainter::Antialiasing, true);
-
-    painter.setPen(QPen(Qt::transparent, 1));
-    painter.setBrush(QBrush(col_menu));
-    QPainterPath painterPath;
-    painterPath.addRoundedRect(QRect(0, 0, width(), height()), 18, 18);
-    painter.drawPath(painterPath);
 }
 
 bool ChameleonSplitMenu::eventFilter(QObject *obj, QEvent *event)
@@ -453,11 +443,11 @@ void ChameleonSplitMenu::Show(const QRect& screenGeom, QPoint pos, QColor color)
 
     QSize menuSize;
     if (m_isSupportFourSplit) {//surpport four split
-        pos.setX(m_pos.x() - 91);
-        menuSize = QSize(224, 160);
+        pos.setX(m_pos.x() - 90);
+        menuSize = QSize(222, 158);
     } else {
-        pos.setX(m_pos.x() - 37);
-        menuSize = QSize(119, 87);
+        pos.setX(m_pos.x() - 36);
+        menuSize = QSize(116, 84);
     }
     setFixedSize(menuSize);
     QRect displayRect = QRect(pos, QSize(menuSize.width(), menuSize.height()));

--- a/src/plugins/kdecorations/deepin-chameleon/deepin/light/icons/four_split_frame.svg
+++ b/src/plugins/kdecorations/deepin-chameleon/deepin/light/icons/four_split_frame.svg
@@ -1,29 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="224px" height="160px" viewBox="0 0 224 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>编组 2</title>
-    <defs>
-        <rect id="path-1" x="0" y="0" width="222" height="158" rx="18"></rect>
-    </defs>
+<svg width="222px" height="158px" viewBox="0 0 222 158" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>编组 6</title>
     <g id="多分屏" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="通过分屏菜单触发分屏" transform="translate(-1415.000000, -218.000000)">
-            <g id="编组-2" transform="translate(1416.000000, 219.000000)">
-                <g id="menu_bg">
-                    <use fill-opacity="0.8" fill="#EEEEEE" fill-rule="evenodd" xlink:href="#path-1"></use>
-                    <rect stroke-opacity="0.06" stroke="#000000" stroke-width="1" x="-0.5" y="-0.5" width="223" height="159" rx="18"></rect>
-                    <rect stroke-opacity="0.1" stroke="#FFFFFF" stroke-width="1" stroke-linejoin="square" x="0.5" y="0.5" width="221" height="157" rx="18"></rect>
-                </g>
-                <g id="编组-3" transform="translate(10.000000, 10.000000)" stroke="#000000" stroke-opacity="0.1">
-                    <rect id="矩形" x="0.5" y="0.5" width="95" height="63" rx="8"></rect>
-                </g>
-                <g id="编组-3" transform="translate(116.000000, 10.000000)" stroke="#000000" stroke-opacity="0.1">
-                    <rect id="矩形" x="0.5" y="0.5" width="95" height="63" rx="8"></rect>
-                </g>
-                <g id="编组-3" transform="translate(116.000000, 84.000000)" stroke="#000000" stroke-opacity="0.1">
-                    <rect id="矩形" x="0.5" y="0.5" width="95" height="63" rx="8"></rect>
-                </g>
-                <g id="编组-3" transform="translate(58.000000, 116.000000) scale(-1, 1) translate(-58.000000, -116.000000) translate(10.000000, 84.000000)" stroke="#000000" stroke-opacity="0.1">
-                    <rect id="矩形" x="0.5" y="0.5" width="95" height="63" rx="8"></rect>
-                </g>
+        <g id="通过分屏菜单触发分屏" transform="translate(-862, -226)">
+            <g id="编组-6" transform="translate(862, 226)">
+                <rect id="menu_bg" fill-opacity="0.8" fill="#EEEEEE" x="0" y="0" width="222" height="158"></rect>
+                <rect id="矩形" stroke-opacity="0.1" stroke="#000000" x="10.5" y="10.5" width="95" height="63" rx="8"></rect>
+                <rect id="矩形" stroke-opacity="0.1" stroke="#000000" x="116.5" y="10.5" width="95" height="63" rx="8"></rect>
+                <rect id="矩形" stroke-opacity="0.1" stroke="#000000" x="116.5" y="84.5" width="95" height="63" rx="8"></rect>
+                <rect id="矩形" stroke-opacity="0.1" stroke="#000000" transform="translate(58, 116) scale(-1, 1) translate(-58, -116)" x="10.5" y="84.5" width="95" height="63" rx="8"></rect>
             </g>
         </g>
     </g>

--- a/src/plugins/kdecorations/deepin-chameleon/deepin/light/icons/two_split_frame.svg
+++ b/src/plugins/kdecorations/deepin-chameleon/deepin/light/icons/two_split_frame.svg
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="119px" height="87px" viewBox="0 0 119 87" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>编组 2</title>
-    <defs>
-        <rect id="path-1" x="0" y="0" width="117" height="85" rx="18"></rect>
-    </defs>
+<svg width="116px" height="84px" viewBox="0 0 116 84" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>编组 8</title>
     <g id="多分屏" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="通过分屏菜单触发分屏" transform="translate(-1415.000000, -460.000000)">
-            <g id="编组-2" transform="translate(1416.000000, 461.000000)">
-                <g id="menu_bg">
-                    <use fill-opacity="0.8" fill="#EEEEEE" fill-rule="evenodd" xlink:href="#path-1"></use>
-                    <rect stroke-opacity="0.06" stroke="#000000" stroke-width="1" x="-0.5" y="-0.5" width="118" height="86" rx="18"></rect>
-                    <rect stroke-opacity="0.1" stroke="#FFFFFF" stroke-width="1" stroke-linejoin="square" x="0.5" y="0.5" width="116" height="84" rx="18"></rect>
-                </g>
-                <g id="编组-3" transform="translate(10.000000, 10.000000)" stroke="#000000" stroke-opacity="0.1">
-                    <rect id="矩形" x="0.5" y="0.5" width="95" height="63" rx="8"></rect>
-                </g>
+        <g id="通过分屏菜单触发分屏" transform="translate(-1084, -461)">
+            <g id="编组-8" transform="translate(1084, 461)">
+                <rect id="menu_bg" fill-opacity="0.8" fill="#EEEEEE" x="0" y="0" width="116" height="84"></rect>
+                <rect id="矩形" stroke-opacity="0.1" stroke="#000000" x="10.5" y="10.5" width="95" height="63" rx="8"></rect>
             </g>
         </g>
     </g>


### PR DESCRIPTION
Radius of split menu does sync with window radius. Just let window manager decide the window radius.

Log: fix incorrect radius of split menu