### PR TITLE
fix: missing owner changed signal

### DIFF
--- a/src/plugins/kdecorations/deepin-chameleon/chameleonconfig.h
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonconfig.h
@@ -118,6 +118,7 @@ private Q_SLOTS:
 
     void onShellClientAdded(KWin::ShellClient *client);
     void updateWindowRadius();
+    void updateAppearanceConn();
 
 private:
     void init();


### PR DESCRIPTION
ChameleonConfig::init may be invoked after appearance interface is ready, therefore cannot receive ownerChanged signal. Just try once in init and then connect to watcher.

Log: fix missing owner changed signal