### PR TITLE
fix: user actions menu's font not follow system

### DIFF
--- a/src/useractions.cpp
+++ b/src/useractions.cpp
@@ -300,8 +300,6 @@ void UserActionsMenu::prepareMenu(const QPointer<AbstractClient> &cl)
             border-radius:0px;\
             }\
             QMenu::item {\
-            font:Sans Serif;\
-            font-size:14px;\
             padding: 6px 45px 6px 30px;\
             color: %3;\
             }\


### PR DESCRIPTION
Log: when unset font in QSS, it works

https://github.com/linuxdeepin/developer-center/issues/6119
https://github.com/linuxdeepin/developer-center/issues/4932