### PR TITLE
chore: remove outdate xcb property setting for gtk

### DIFF
--- a/src/rootinfo_filter.cpp
+++ b/src/rootinfo_filter.cpp
@@ -64,33 +64,6 @@ bool RootInfoFilter::event(xcb_generic_event_t *event)
     if (dirtyProtocols2 & NET::WM2DesktopLayout)
         VirtualDesktopManager::self()->updateLayout();
 
-    // TODO(zccrs): 应该在 kwindowsystem 项目的 NETRootInfo 中添加
-    if ((event->response_type & ~0x80) == XCB_PROPERTY_NOTIFY) {
-        xcb_property_notify_event_t *pe = reinterpret_cast<xcb_property_notify_event_t*>(event);
-        Xcb::Atom net_support(QByteArrayLiteral("_NET_SUPPORTED"));
-        xcb_atom_t gtk_frame_extents = atoms->gtk_frame_extents;
-
-        if (pe->atom == net_support) {
-            auto old_atoms = getNetWMAtoms(net_support);
-            QVector<xcb_atom_t> new_atoms;
-
-            if (!old_atoms.contains(gtk_frame_extents)) {
-                // Append _GTK_FRAME_EXTENTS atom to _NET_SUPPORTED
-                new_atoms << gtk_frame_extents;
-            }
-
-            if (!old_atoms.contains(atoms->gtk_show_window_menu)) {
-                // Support _GTK_SHOW_WINDOW_MENU
-                new_atoms << atoms->gtk_show_window_menu;
-            }
-
-            if (!new_atoms.isEmpty()) {
-                xcb_change_property(connection(), XCB_PROP_MODE_APPEND, rootWindow(),
-                                    net_support, XCB_ATOM_ATOM, 32, new_atoms.length(), new_atoms.constData());
-            }
-        }
-    }
-
     return false;
 }
 


### PR DESCRIPTION
Log: _GTK_SHOW_WINDOW_MENU 和 _GTK_FRAME_EXTENTS 已经在 kwindowsystem 中设置了