### PR TITLE
fix: don't set deactive when window list is empty after removeWinAndR…

### DIFF
--- a/src/effects/multitaskview/multitaskview.cpp
+++ b/src/effects/multitaskview/multitaskview.cpp
@@ -3371,6 +3371,9 @@ void MultitaskViewEffect::removeWinAndRelayout(EffectWindow *w)
         }
     }
 
+    // Don't set deactive when window list is empty, this may be an intermediate state
+
+    /*
     for (int i = 0; i < effects->numberOfDesktops(); i++) {
         MultiViewWinManager *wmobj = getWinManagerObject(i);
         EffectWindowList list;
@@ -3383,6 +3386,7 @@ void MultitaskViewEffect::removeWinAndRelayout(EffectWindow *w)
     }
 
     setActive(false);
+    */
 }
 
 void MultitaskViewEffect::moveWindowChangeDesktop(EffectWindow *w, int todesktop, EffectScreen *toscreen, bool isSwitch)


### PR DESCRIPTION
…elayout

Isuue: https://github.com/linuxdeepin/developer-center/issues/8227

removeWinAndRelayout 期间退出多任务视图时机不对，可能有 Add
未处理，并且即使window list为空了，多任务视图仍然是需要显示的

wine 应用（比如 QQ影音，央视影音容易触发）