### PR TITLE
fix: cache background file list in kwin

### DIFF
--- a/src/effects/multitaskview/multitaskview.h
+++ b/src/effects/multitaskview/multitaskview.h
@@ -110,6 +110,9 @@ private:
     };
     static CGarbo Garbo;
 
+public:
+    QHash<QString, QVector<QString>> m_allBackgroundList; // monitor name -> background list
+
 private:
     QSet<QString>    m_backgroundAllList;
     QSet<QString>    m_currentBackgroundList;
@@ -123,7 +126,6 @@ private:
     QHash<QString, QPair<QSize, QPixmap>> m_wpCachedPixmaps;
     QHash<QString, QPair<QSize, QPixmap>> m_bgCachedPixmaps;
     QList<QMap<QString,QVariant>> m_monitorInfoList;
-
 };
 
 class MultiViewWorkspace : public QObject


### PR DESCRIPTION
log: dde-appearance 壁纸相关设置的部分接口需要通过 dbus 调用 kwin
接口导致卡钝，之前使用 QDBus::BlockWithGui 避免，但是引入其他问题
在 multitaskview 保存一份数据避免调用 dbus