### PR TITLE
 fix: segmentation fault when stop compositing && 5.25.27-kwin.5.24.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-kwin (4:5.25.27-kwin.5.24.3) unstable; urgency=medium
+
+  * segmentation fault when stop compositing
+
+ -- rewine <luhongxu@deepin.org>  Mon, 13 Mar 2024 24:35:52 +0800
+
 deepin-kwin (4:5.25.26-kwin.5.24.3) unstable; urgency=medium
 
   * fix alt tab

--- a/src/plugins/kdecorations/deepin-chameleon/chameleon.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleon.cpp
@@ -532,7 +532,10 @@ void Chameleon::updateConfig()
     m_config = active ? m_baseConfigGroup->normal : m_baseConfigGroup->inactive;
 
     updateMouseInputAreaMargins();
+    QPointer<Chameleon> thisPtr(this);
     updateTitleBarArea();
+    if(thisPtr.isNull())
+        return;
     // 解决关闭应用更新shadow闪屏的问题(bug87758)
     // if ((c == sender()) && !active) {
     //     return;
@@ -562,6 +565,7 @@ void Chameleon::updateTitleBarArea()
     qreal border_width = windowNeedBorder() ? borderWidth() : 0;
     qreal titlebar_height = noTitleBar() ? 0 : titleBarHeight();
 
+    QPointer<Chameleon> thisPtr(this);
     switch (m_config.titlebarConfig.area) {
     case Qt::LeftEdge:
         m_titleBarAreaMargins.setLeft(titlebar_height);
@@ -593,6 +597,8 @@ void Chameleon::updateTitleBarArea()
     default:
         return;
     }
+    if (thisPtr.isNull())
+        return;
 
     updateBorderPath();
     updateButtonsGeometry();


### PR DESCRIPTION
setBorders 触发 updateShape 时如果 dde-launchpad 没有来得及设置边框，可能会析构 Chameleon