### PR TITLE
fix: titlebar right-click menu translation error

### DIFF
--- a/po/be/deepin-kwin.po
+++ b/po/be/deepin-kwin.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Crowdin-Project: 86ff119b1606fcaa910d6b44fc14b611\n"
 "X-Crowdin-Project-ID: 127\n"
 "X-Crowdin-Language: be\n"
-"X-Crowdin-File: /main/be/kwin/kwin.po\n"
+"X-Crowdin-File: /main/be/kwin/deepin-kwin.po\n"
 "X-Crowdin-File-ID: 8365\n"
 
 #, kde-format

--- a/po/be@latin/deepin-kwin.po
+++ b/po/be@latin/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Belarusian Latin
+# translation of deepin-kwin.po to Belarusian Latin
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/bn/deepin-kwin.po
+++ b/po/bn/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Bengali
+# translation of deepin-kwin.po to Bengali
 # Deepayan Sarkar <deepayan@bengalinux.org>, 2004, 2005, 2006.
 # Deepayan Sarkar <deepayan.sarkar@gmail.com>, 2009.
 msgid ""

--- a/po/bn/deepin-kwin_effects.po
+++ b/po/bn/deepin-kwin_effects.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Bengali
+# translation of deepin-kwin.po to Bengali
 # Deepayan Sarkar <deepayan@bengalinux.org>, 2004, 2005, 2006.
 # Deepayan Sarkar <deepayan.sarkar@gmail.com>, 2009, 2010.
 msgid ""

--- a/po/bn_IN/deepin-kwin.po
+++ b/po/bn_IN/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Bengali INDIA
+# translation of deepin-kwin.po to Bengali INDIA
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/bs/deepin-kwin.po
+++ b/po/bs/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to bosanski
+# translation of deepin-kwin.po to bosanski
 # Strahinja Radic <rstraxy@sezampro.yu>, 2000.
 # Tiron Andric <tiron@beotel.yu>, 2003.
 # Toplica Tanaskovic <toptan@kde.org.yu>, 2003.

--- a/po/ca/deepin-kwin.po
+++ b/po/ca/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po to Catalan
+# Translation of deepin-kwin.po to Catalan
 # Copyright (C) 1999-2023 This_file_is_part_of_KDE
 # This file is distributed under the license LGPL version 2.1 or
 # version 3 or later versions approved by the membership of KDE e.V.

--- a/po/ca@valencia/deepin-kwin.po
+++ b/po/ca@valencia/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po to Catalan (Valencian)
+# Translation of deepin-kwin.po to Catalan (Valencian)
 # Copyright (C) 1999-2023 This_file_is_part_of_KDE
 # This file is distributed under the license LGPL version 2.1 or
 # version 3 or later versions approved by the membership of KDE e.V.

--- a/po/csb/deepin-kwin.po
+++ b/po/csb/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Kashubian
+# translation of deepin-kwin.po to Kashubian
 #
 # Michôł Òstrowsczi <michol@linuxcsb.org>, 2006, 2007, 2009.
 # Mark Kwidzińsczi <mark@linuxcsb.org>, 2008.

--- a/po/cy/deepin-kwin.po
+++ b/po/cy/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to Cymraeg
-# Translation of kwin.po to Cymraeg
+# translation of deepin-kwin.po to Cymraeg
+# Translation of deepin-kwin.po to Cymraeg
 # Bwrdd Gwaith yn Gymraeg.
 # Copyright (C) 2003 Free Software Foundation, Inc.
 # www.kyfieithu.co.uk<kyfieithu@dotmon.com>, www.gyfieithu.co.uk<kyfieithu@dotmon.com>, 2003.

--- a/po/el/deepin-kwin.po
+++ b/po/el/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to greek
-# translation of kwin.po to
+# translation of deepin-kwin.po to greek
+# translation of deepin-kwin.po to
 # Copyright (C) 2002, 2003, 2005, 2007, 2008 Free Software Foundation, Inc.
 #
 # Dimitris Kamenopoulos <el97146@mail.ntua.gr>, 2001.

--- a/po/en_GB/deepin-kwin.po
+++ b/po/en_GB/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to British English
+# translation of deepin-kwin.po to British English
 # Copyright (C) 2003, 2004, 2005, 2008 Free Software Foundation, Inc.
 #
 # Malcolm Hunter <malcolm.hunter@gmx.co.uk>, 2003, 2004, 2005, 2008.

--- a/po/eo/deepin-kwin.po
+++ b/po/eo/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to esperanto
+# translation of deepin-kwin.po to esperanto
 # e-aj mesaĝoj de kwin
 # Copyright (C) 1999, 2004, 2007, 2008 Free Software Foundation, Inc.
 # Wolfram Diestel <wolfram@steloj.de>, 1999.

--- a/po/es/deepin-kwin.po
+++ b/po/es/deepin-kwin.po
@@ -1,7 +1,7 @@
-# Translation of kwin.po to Spanish
+# Translation of deepin-kwin.po to Spanish
 # Translation of kwin to Spanish
-# traducción de kwin.po a Español
-# translation of kwin.po to Spanish
+# traducción de deepin-kwin.po a Español
+# translation of deepin-kwin.po to Spanish
 # Translation to spanish
 # Copyright (C) 1999-2002.
 #

--- a/po/et/deepin-kwin.po
+++ b/po/et/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Estonian
+# translation of deepin-kwin.po to Estonian
 # Copyright (C) 1999,2002, 2003 Free Software Foundation, Inc.
 #
 #

--- a/po/eu/deepin-kwin.po
+++ b/po/eu/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation for kwin.po to Euskara/Basque (eu).
+# Translation for deepin-kwin.po to Euskara/Basque (eu).
 # Copyright (C) 2002-2023 This file is copyright:
 # This file is distributed under the same license as the kwin package.
 # KDE euskaratzeko proiektuko arduraduna <xalba@ni.eus>.

--- a/po/fa/deepin-kwin.po
+++ b/po/fa/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Persian
+# translation of deepin-kwin.po to Persian
 # Nasim Daniarzadeh <daniarzadeh@itland.ir>, 2006, 2007.
 # Nazanin Kazemi <kazemi@itland.ir>, 2006, 2007.
 # Tahereh Dadkhahfar <dadkhahfar@itland.ir>, 2006.

--- a/po/fi/deepin-kwin.po
+++ b/po/fi/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po to Finnish
+# Translation of deepin-kwin.po to Finnish
 # KDE Finnish translation sprint participants:
 # Author: Artnay
 # Author: Lliehu

--- a/po/fr/deepin-kwin.po
+++ b/po/fr/deepin-kwin.po
@@ -1,7 +1,7 @@
-# translation of kwin.po to
-# traduction de kwin.po en français
-# translation of kwin.po to Français
-# traduction de kwin.po en Français
+# translation of deepin-kwin.po to
+# traduction de deepin-kwin.po en français
+# translation of deepin-kwin.po to Français
+# traduction de deepin-kwin.po en Français
 # Traduction de kwin en Français
 # Copyright (C) 2002,2003, 2004, 2005, 2008 Free Software Foundation, Inc.
 # Gérard Delafond <gerard@delafond.org>, 2002, 2003, 2004.

--- a/po/fy/deepin-kwin.po
+++ b/po/fy/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to Frysk
-# translation of kwin.po to
+# translation of deepin-kwin.po to Frysk
+# translation of deepin-kwin.po to
 #
 # Rinse de Vries <rinsedevries@kde.nl>, 2005, 2006, 2007, 2009.
 # berend ytsma <berendy@bigfoot.com>, 2005.

--- a/po/ga/deepin-kwin.po
+++ b/po/ga/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Irish
+# translation of deepin-kwin.po to Irish
 # Copyright (C) 2002 Free Software Foundation, Inc.
 # Séamus Ó Ciardhuáin <seoc@cnds.ucd.ie>, 2002
 # Kevin Scannell <kscanne@gmail.com>, 2009

--- a/po/gl/deepin-kwin.po
+++ b/po/gl/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to galician
+# translation of deepin-kwin.po to galician
 # Galician translation of kwin.
 # Copyright (C) 2000 Jesús Bravo Álvarez.
 # Jesús Bravo Álvarez <jba@pobox.com>, 2000.

--- a/po/gu/deepin-kwin.po
+++ b/po/gu/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Gujarati translation of kwin.po.
+# Gujarati translation of deepin-kwin.po.
 # Copyright (C) 2008 This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 # Kartik Mistry <kartik.mistry@gmail.com>

--- a/po/he/deepin-kwin.po
+++ b/po/he/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to
+# translation of deepin-kwin.po to
 # KDE Hebrew Localization Project
 #
 # In addition to the copyright owners of the program

--- a/po/hi/deepin-kwin.po
+++ b/po/hi/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Hindi
+# translation of deepin-kwin.po to Hindi
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/hne/deepin-kwin.po
+++ b/po/hne/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Hindi
+# translation of deepin-kwin.po to Hindi
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/hsb/deepin-kwin.po
+++ b/po/hsb/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Upper Sorbian
+# translation of deepin-kwin.po to Upper Sorbian
 # Copyright (C) 2003, 2004 Free Software Foundation, Inc.
 #
 # Prof. Dr. Eduard Werner <e.werner@rz.uni-leipzig.de>, 2003, 2004.

--- a/po/is/deepin-kwin.po
+++ b/po/is/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to Icelandic
-# Íslensk þýðing kwin.po
+# translation of deepin-kwin.po to Icelandic
+# Íslensk þýðing deepin-kwin.po
 # Copyright (C) 2000,2003, 2005, 2008, 2009, 2010 Free Software Foundation, Inc.
 #
 # Bjarni R. Einarsson <bre@netverjar.is>, 2000.

--- a/po/it/deepin-kwin.po
+++ b/po/it/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Italian
+# translation of deepin-kwin.po to Italian
 # Andrea Rizzi <rizzi@kde.org>, 2003, 2004, 2005.
 # Andrea RIZZI <arizzi@pi.infn.it>, 2004.
 # Luciano Montanaro <mikelima@cirulla.net>, 2007, 2008, 2010, 2011, 2012.

--- a/po/kk/deepin-kwin.po
+++ b/po/kk/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Karakh
+# translation of deepin-kwin.po to Karakh
 #
 # Sairan Kikkarin <sairan@computer.org>, 2005, 2006, 2007, 2008, 2009, 2010.
 # Sairan Kikkarin <sairan@computer.org>, 2010, 2011.

--- a/po/km/deepin-kwin.po
+++ b/po/km/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Khmer
+# translation of deepin-kwin.po to Khmer
 # Khoem Sokhem <khoemsokhem@khmeros.info>, 2007, 2008, 2009, 2010, 2012.
 msgid ""
 msgstr ""

--- a/po/kn/deepin-kwin.po
+++ b/po/kn/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to Kannada
-# translation of kwin.po to
+# translation of deepin-kwin.po to Kannada
+# translation of deepin-kwin.po to
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/ku/deepin-kwin.po
+++ b/po/ku/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Kurdish
+# translation of deepin-kwin.po to Kurdish
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/lt/deepin-kwin.po
+++ b/po/lt/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to
+# translation of deepin-kwin.po to
 # Donatas Glodenis <dgvirtual@akl.lt>, 2004-2009, 2012.
 # Tomas Straupis <tomasstraupis@gmail.com>, 2010, 2011.
 # Remigijus Jarmalavičius <remigijus@jarmalavicius.lt>, 2011.

--- a/po/lv/deepin-kwin.po
+++ b/po/lv/deepin-kwin.po
@@ -1,6 +1,6 @@
-# translation of kwin.po to Latvian
-# translation of kwin.po to
-# kwin.po tulkojums uz Latviešu valodu
+# translation of deepin-kwin.po to Latvian
+# translation of deepin-kwin.po to
+# deepin-kwin.po tulkojums uz Latviešu valodu
 # Copyright (C) 2005, 2006, 2007, 2008 Free Software Foundation, Inc.
 #
 # Maris Nartiss <maris.nartiss@gmail.com>, 2005.

--- a/po/mai/deepin-kwin.po
+++ b/po/mai/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Maithili
+# translation of deepin-kwin.po to Maithili
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/mk/deepin-kwin.po
+++ b/po/mk/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Macedonian
+# translation of deepin-kwin.po to Macedonian
 # Copyright (C) 2000,2002,2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
 #
 #

--- a/po/ml/deepin-kwin.po
+++ b/po/ml/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to
+# translation of deepin-kwin.po to
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 # ANI PETER|അനി പീറ്റര്‍ <peter.ani@gmail.com>, 2008

--- a/po/mr/deepin-kwin.po
+++ b/po/mr/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to marathi
+# translation of deepin-kwin.po to marathi
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/nds/deepin-kwin.po
+++ b/po/nds/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po to Low Saxon
+# Translation of deepin-kwin.po to Low Saxon
 # Copyright (C) 2004, 2005, 2006, 2007, 2008 Free Software Foundation, Inc.
 # Heiko Evermann <heiko@evermann.de>, 2004.
 # Sönke Dibbern <s_dibbern@web.de>, 2004, 2005, 2006, 2007, 2008, 2009, 2014.

--- a/po/ne/deepin-kwin.po
+++ b/po/ne/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Nepali
+# translation of deepin-kwin.po to Nepali
 # Nabin Gautam <nabin@mpp.org.np>, 2006, 2007.
 # Kapil Timilsina <lipak21@gmail.com>, 2006.
 # Shyam Krishna Bal <shyam@mpp.org.np>, 2006.

--- a/po/nl/deepin-kwin.po
+++ b/po/nl/deepin-kwin.po
@@ -1,6 +1,6 @@
-# translation of kwin.po to Dutch
-# translation of kwin.po to
-# translation of kwin.po to
+# translation of deepin-kwin.po to Dutch
+# translation of deepin-kwin.po to
+# translation of deepin-kwin.po to
 # KTranslator Generated File
 # Nederlandse vertaling van kwin
 # Copyright (C) 2000, 2001, 2002 KDE e.v.

--- a/po/oc/deepin-kwin.po
+++ b/po/oc/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to Occitan (lengadocian)
-# Occitan translation of kwin.po
+# translation of deepin-kwin.po to Occitan (lengadocian)
+# Occitan translation of deepin-kwin.po
 # Copyright (C) 2002,2003, 2004, 2005, 2007, 2008 Free Software Foundation, Inc.
 #
 # Yannig MARCHEGAY (Kokoyaya) <yannig@marchegay.org> - 2006-2007

--- a/po/or/deepin-kwin.po
+++ b/po/or/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Oriya
+# translation of deepin-kwin.po to Oriya
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/pa/deepin-kwin.po
+++ b/po/pa/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Punjabi
+# translation of deepin-kwin.po to Punjabi
 # Amanpreet Singh Alam <aalam@redhat.com>, 2004, 2005.
 # Amanpreet Singh Alam <amanpreetalam@yahoo.com>, 2005.
 # Amanpreet Singh Brar <aalam@redhat.com>, 2005.

--- a/po/pl/deepin-kwin.po
+++ b/po/pl/deepin-kwin.po
@@ -1,7 +1,7 @@
-# translation of kwin.po to
+# translation of deepin-kwin.po to
 # Version: $Revision: 1645600 $
-# translation of kwin.po to Polish
-# translation of kwin.po to
+# translation of deepin-kwin.po to Polish
+# translation of deepin-kwin.po to
 # Norbert Popiołek <norbert@kde.com.pl>
 # Michał Rudolf <mrudolf@kdewebdev.org>, 2002.
 # Michal Rudolf <mrudolf@kdewebdev.org>, 2002, 2003.

--- a/po/pt_BR/deepin-kwin.po
+++ b/po/pt_BR/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po to Brazilian Portuguese
+# Translation of deepin-kwin.po to Brazilian Portuguese
 # Copyright (C) 2002-2020 This file is copyright:
 # This file is distributed under the same license as the kwin package.
 #

--- a/po/ro/deepin-kwin.po
+++ b/po/ro/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Traducerea kwin.po în Română
+# Traducerea deepin-kwin.po în Română
 # Copyright (C) 2008 This_file_is_part_of_KDE
 # This file is distributed under the same license as the kwrite package.
 # Laurenţiu Buzdugan <lbuz@rolix.org>, 2008, 2009".

--- a/po/ru/deepin-kwin.po
+++ b/po/ru/deepin-kwin.po
@@ -1,9 +1,9 @@
-# translation of kwin.po into Russian
-# translation of kwin.po to
+# translation of deepin-kwin.po into Russian
+# translation of deepin-kwin.po to
 # translation of 1.po to Russian
 #
-# translation of kwin.po to Russian
-# KDE3 - kwin.pot Russian translationю
+# translation of deepin-kwin.po to Russian
+# KDE3 - deepin-kwin.pot Russian translationю
 # Copyright (C) 2000 KDE Team.
 #
 # Alex Miller <asm@som.kiev.ua>, 2000.

--- a/po/sk/deepin-kwin.po
+++ b/po/sk/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Slovak
+# translation of deepin-kwin.po to Slovak
 # Stanislav Visnovsky <stano@ms.mff.cuni.cz>, 2002.
 # Stanislav Višňovský <visnovsky@nenya.ms.mff.cuni.cz>, 2002.
 # Stanislav Visnovsky <visnovsky@nenya.ms.mff.cuni.cz>, 2002.

--- a/po/sl/deepin-kwin.po
+++ b/po/sl/deepin-kwin.po
@@ -1,7 +1,7 @@
-# translation of kwin.po to
-# Translation of kwin.po to Slovenian
+# translation of deepin-kwin.po to
+# Translation of deepin-kwin.po to Slovenian
 # Copyright (C) 2001, 2003, 2004, 2005, 2007 Free Software Foundation, Inc.
-# $Id: kwin.po 1645600 2023-02-28 03:35:00Z scripty $
+# $Id: deepin-kwin.po 1645600 2023-02-28 03:35:00Z scripty $
 # $Source$
 #
 #

--- a/po/sr/deepin-kwin.po
+++ b/po/sr/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po into Serbian.
+# Translation of deepin-kwin.po into Serbian.
 # Strahinja Radic <rstraxy@sezampro.yu>, 2000.
 # Tiron Andric <tiron@beotel.yu>, 2003.
 # Toplica Tanaskovic <toptan@kde.org.yu>, 2003.

--- a/po/sr@ijekavian/deepin-kwin.po
+++ b/po/sr@ijekavian/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po into Serbian.
+# Translation of deepin-kwin.po into Serbian.
 # Strahinja Radic <rstraxy@sezampro.yu>, 2000.
 # Tiron Andric <tiron@beotel.yu>, 2003.
 # Toplica Tanaskovic <toptan@kde.org.yu>, 2003.

--- a/po/sr@ijekavianlatin/deepin-kwin.po
+++ b/po/sr@ijekavianlatin/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po into Serbian.
+# Translation of deepin-kwin.po into Serbian.
 # Strahinja Radic <rstraxy@sezampro.yu>, 2000.
 # Tiron Andric <tiron@beotel.yu>, 2003.
 # Toplica Tanaskovic <toptan@kde.org.yu>, 2003.

--- a/po/sr@latin/deepin-kwin.po
+++ b/po/sr@latin/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po into Serbian.
+# Translation of deepin-kwin.po into Serbian.
 # Strahinja Radic <rstraxy@sezampro.yu>, 2000.
 # Tiron Andric <tiron@beotel.yu>, 2003.
 # Toplica Tanaskovic <toptan@kde.org.yu>, 2003.

--- a/po/sv/deepin-kwin.po
+++ b/po/sv/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to Swedish
-# Översättning kwin.po till Svenska
+# translation of deepin-kwin.po to Swedish
+# Översättning deepin-kwin.po till Svenska
 # Copyright (C) 1999,2003, 2004, 2005, 2007, 2008, 2009 Free Software Foundation, Inc.
 #
 # Anders Widell <d95-awi@nada.kth.se>, 1999.

--- a/po/ta/deepin-kwin.po
+++ b/po/ta/deepin-kwin.po
@@ -1,6 +1,6 @@
-# translation of kwin.po to
-# translation of kwin.po to
-# translation of kwin.po to Tamil
+# translation of deepin-kwin.po to
+# translation of deepin-kwin.po to
+# translation of deepin-kwin.po to Tamil
 # Copyright (C) 2004 Free Software Foundation, Inc.
 #
 # Vasee Vaseeharan <vasee@ieee.org>, 2004.

--- a/po/te/deepin-kwin.po
+++ b/po/te/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Telugu
+# translation of deepin-kwin.po to Telugu
 # Copyright (C) YEAR This_file_is_part_of_KDE
 # This file is distributed under the same license as the PACKAGE package.
 #

--- a/po/tg/deepin-kwin.po
+++ b/po/tg/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Tajik
+# translation of deepin-kwin.po to Tajik
 # Copyright (C) 2002,2004 Free Software Foundation, Inc.
 # Victor Ibragimov <victor.ibragimov@gmail.com>, 2019.
 msgid ""

--- a/po/th/deepin-kwin.po
+++ b/po/th/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Thai
+# translation of deepin-kwin.po to Thai
 # Copyright (C) 2003, 2005, 2008 Free Software Foundation, Inc.
 #
 # Thanomsub Noppaburana <donga_n@yahoo.com>, 2003, 2005.

--- a/po/tr/deepin-kwin.po
+++ b/po/tr/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to Turkish
-# translation of kwin.po to
+# translation of deepin-kwin.po to Turkish
+# translation of deepin-kwin.po to
 # Copyright (C) 2003, 2004, 2005, 2008 Free Software Foundation, Inc.
 # Murat Sisman <muratsisman@mailcity.com>, 2000.
 # Ömer Fadıl USTA <omer_fad@hotmail.com>, 2003.

--- a/po/uk/deepin-kwin.po
+++ b/po/uk/deepin-kwin.po
@@ -1,4 +1,4 @@
-# Translation of kwin.po to Ukrainian
+# Translation of deepin-kwin.po to Ukrainian
 # Copyright (C) 2002-2021 This_file_is_part_of_KDE
 # This file is distributed under the license LGPL version 2.1 or
 # version 3 or later versions approved by the membership of KDE e.V.

--- a/po/uz/deepin-kwin.po
+++ b/po/uz/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to
+# translation of deepin-kwin.po to
 # Copyright (C) 2003, 2004, 2005, 2006 Free Software Foundation, Inc.
 #
 # Mashrab Kuvatov <kmashrab@uni-bremen.de>, 2003, 2004, 2005, 2006.

--- a/po/uz@cyrillic/deepin-kwin.po
+++ b/po/uz@cyrillic/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to
+# translation of deepin-kwin.po to
 # Copyright (C) 2003, 2004, 2005, 2006 Free Software Foundation, Inc.
 #
 # Mashrab Kuvatov <kmashrab@uni-bremen.de>, 2003, 2004, 2005, 2006.

--- a/po/wa/deepin-kwin.po
+++ b/po/wa/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Walloon
+# translation of deepin-kwin.po to Walloon
 # Ratournaedje e walon des messaedjes di KDE.
 #
 # Pablo Saratxaga <pablo@walon.org>, 2007.

--- a/po/xh/deepin-kwin.po
+++ b/po/xh/deepin-kwin.po
@@ -1,5 +1,5 @@
-# translation of kwin.po to
-# translation of kwin.po to Xhosa
+# translation of deepin-kwin.po to
+# translation of deepin-kwin.po to Xhosa
 # K Desktop Environment - kwin
 # Copyright (C) 2001 translate.org.za
 # Antoinette Dekeni <antoinette@transalate.org.za>, 2001.

--- a/po/zh_CN/deepin-kwin.po
+++ b/po/zh_CN/deepin-kwin.po
@@ -14,7 +14,7 @@ msgstr ""
 "X-Crowdin-Project: kdeorg\n"
 "X-Crowdin-Project-ID: 269464\n"
 "X-Crowdin-Language: zh-CN\n"
-"X-Crowdin-File: /kf5-stable/messages/kwin/kwin.pot\n"
+"X-Crowdin-File: /kf5-stable/messages/kwin/deepin-kwin.pot\n"
 "X-Crowdin-File-ID: 2637\n"
 
 #, kde-format

--- a/po/zh_TW/deepin-kwin.po
+++ b/po/zh_TW/deepin-kwin.po
@@ -1,4 +1,4 @@
-# translation of kwin.po to Chinese Traditional
+# translation of deepin-kwin.po to Chinese Traditional
 # Copyright (C) 2001, 2002, 2003, 2007, 2008 Free Software Foundation, Inc.
 #
 # Kenduest Lee <kenduest@i18n.linux.org.tw>, 2001.

--- a/src/Messages.sh
+++ b/src/Messages.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 $EXTRACTRC *.kcfg *.ui >> rc.cpp
-$XGETTEXT *.h *.cpp plugins/nightcolor/*.cpp helpers/killer/*.cpp scene/*.cpp tabbox/*.cpp scripting/*.cpp plugins/krunner-integration/*.cpp -o $podir/kwin.pot
+$XGETTEXT *.h *.cpp plugins/nightcolor/*.cpp helpers/killer/*.cpp scene/*.cpp tabbox/*.cpp scripting/*.cpp plugins/krunner-integration/*.cpp -o $podir/deepin-kwin.pot

--- a/src/helpers/killer/killer.cpp
+++ b/src/helpers/killer/killer.cpp
@@ -24,7 +24,7 @@
 
 int main(int argc, char *argv[])
 {
-    KLocalizedString::setApplicationDomain("kwin");
+    KLocalizedString::setApplicationDomain("deepin-kwin");
     qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("xcb"));
     QApplication app(argc, argv);
     app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,7 +250,7 @@ void Application::setupMalloc()
 
 void Application::setupLocalizedString()
 {
-    KLocalizedString::setApplicationDomain("kwin");
+    KLocalizedString::setApplicationDomain("deepin-kwin");
 }
 
 void Application::createWorkspace()


### PR DESCRIPTION
The translation po file pointed to is incorrect.

Log: titlebar right-click menu translation error
Issue: https://github.com/linuxdeepin/developer-center/issues/9032