### PR TITLE
fix: missing rename for deepin-kwinrc

### DIFF
--- a/kconf_update/deepin-kwin.upd
+++ b/kconf_update/deepin-kwin.upd
@@ -2,19 +2,19 @@ Version=5
 
 # Replace old Scale in effect with Scale effect.
 Id=replace-scalein-with-scale
-File=kwinrc
+File=deepin-kwinrc
 Group=Plugins
 Key=kwin4_effect_scaleinEnabled,scaleEnabled
 
 # Port the Minimize Animation effect to JavaScript.
 Id=port-minimizeanimation-effect-to-js
-File=kwinrc
+File=deepin-kwinrc
 Group=Plugins
 Key=minimizeanimationEnabled,kwin4_effect_squashEnabled
 
 # Port the Scale effect to JavaScript.
 Id=port-scale-effect-to-js
-File=kwinrc
+File=deepin-kwinrc
 Group=Effect-Scale,Effect-kwin4_effect_scale
 AllKeys
 Group=Plugins
@@ -22,84 +22,84 @@ Key=scaleEnabled,kwin4_effect_scaleEnabled
 
 # Port the Dim Screen effect to JavaScript.
 Id=port-dimscreen-effect-to-js
-File=kwinrc
+File=deepin-kwinrc
 Group=Plugins
 Key=dimscreenEnabled,kwin4_effect_dimscreenEnabled
 
 # Deactivate auto border size if the user has changed border size in the past
 Id=auto-bordersize
-File=kwinrc
+File=deepin-kwinrc
 Group=org.kde.kdecoration2
 Script=kwin-5.16-auto-bordersize.sh,sh
 
 # Move AnimationSpeed to kdeglobals as AnimationDurationFactor converting to a useful value
 Id=animation-speed
-File=kwinrc,kdeglobals
+File=deepin-kwinrc,kdeglobals
 Group=Compositing,KDE
 Script=kwin-5.18-move-animspeed.py,python3
 
 # In the Desktop Grid effect, replace the PresentWindows boolean with an enum
 Id=desktop-grid-click-behavior
-File=kwinrc
+File=deepin-kwinrc
 Group=Effect-DesktopGrid
 Script=kwin-5.21-desktop-grid-click-behavior.py,python3
 
 # Remove GLPreferBufferSwap if it has a value of "n"
 Id=no-swap-encourage
-File=kwinrc
+File=deepin-kwinrc
 Group=Compositing
 Script=kwin-5.21-no-swap-encourage.py,python3
 
 # Make the Translucency effect disabled by default
 Id=make-translucency-effect-disabled-by-default
-File=kwinrc
+File=deepin-kwinrc
 Group=Plugins
 Script=kwin-5.23-disable-translucency-effect.sh,sh
 
 # Remove the Flip Switch effect
 Id=remove-flip-switch-effect
-File=kwinrc
+File=deepin-kwinrc
 Group=TabBox,TabBoxAlternative
 Script=kwin-5.23-remove-flip-switch.py,python3
 
 # Remove the Cover Switch effect
 Id=remove-cover-switch-effect
-File=kwinrc
+File=deepin-kwinrc
 Group=TabBox,TabBoxAlternative
 Script=kwin-5.23-remove-cover-switch.py,python3
 
 # Remove the Desktop Cube Animation effect
 Id=remove-cubeslide-effect
-File=kwinrc
+File=deepin-kwinrc
 Group=Plugins
 Script=kwin-5.23-remove-cubeslide.py,python3
 
 # Remove Backend if it has a value of "XRender"
 Id=remove-xrender-backend
-File=kwinrc
+File=deepin-kwinrc
 Group=Compositing
 Script=kwin-5.23-remove-xrender-backend.py,python3
 
 # Enable the Scale effect by default.
 Id=enable-scale-effect-by-default
-File=kwinrc
+File=deepin-kwinrc
 Group=Plugins
 Key=kwin4_effect_fadeEnabled,kwin4_effect_scaleEnabled
 
 # Overview config group based upon plugin id
 Id=overview-group-plugin-id
-File=kwinrc
+File=deepin-kwinrc
 Options=AllGroups
 Script=kwin-5.25-effect-pluginid-config-group.py,python3
 
 # Tidy up after a bug from the animation speed movement
 Id=animation-speed-cleanup
-File=kwinrc
+File=deepin-kwinrc
 Group=KDE
 RemoveKey=AnimationDurationFactor
 
 # Replace the cascaded placement policy by zero-cornered
 Id=replace-cascaded-zerocornered
-File=kwinrc
+File=deepin-kwinrc
 Group=Windows
 Script=kwin-5.27-replace-cascaded-zerocornered.sh,sh

--- a/kconf_update/deepin-kwinrules-5.23-virtual-desktop-ids.py
+++ b/kconf_update/deepin-kwinrules-5.23-virtual-desktop-ids.py
@@ -7,7 +7,7 @@ import subprocess
 
 # Get the config standard locations
 config_locations = subprocess.check_output(['qtpaths', '--paths', 'ConfigLocation']).decode('utf-8').strip().split(':')
-config_paths = [os.path.join(folder, 'kwinrc') for folder in config_locations]
+config_paths = [os.path.join(folder, 'deepin-kwinrc') for folder in config_locations]
 
 # Get the desktops information from `kwinrc` config file
 kwinrc = configparser.ConfigParser(strict=False, allow_no_value=True)

--- a/src/config-kwin.h.cmake
+++ b/src/config-kwin.h.cmake
@@ -6,7 +6,7 @@
 #cmakedefine01 KWIN_BUILD_SCREENLOCKER
 #cmakedefine01 KWIN_BUILD_TABBOX
 #cmakedefine01 KWIN_BUILD_ACTIVITIES
-#define KWIN_CONFIG "kwinrc"
+#define KWIN_CONFIG "deepin-kwinrc"
 #define KWIN_VERSION_STRING "${PROJECT_VERSION}"
 #define XCB_VERSION_STRING "${XCB_VERSION}"
 #define KWIN_KILLER_BIN "${CMAKE_INSTALL_FULL_LIBEXECDIR}/kwin_killer_helper"


### PR DESCRIPTION
log: kwinrc -> deepin-kwinrc