### PR TITLE
fix: cancel trigger splitswap when click browser

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1790,7 +1790,7 @@ void Window::finishInteractiveMoveResize(bool cancel)
     Q_EMIT clientFinishUserMovedResized(this);
     if (needTrigger && isSplitWindow()) {
         Q_EMIT triggerSplitPreview(this);
-    } else if (wasMove && isSplitWindow()) {
+    } else if (wasMove && isSplitWindow() && !m_initPosForSplit.isNull()) {
         Q_EMIT swapSplitWindow(this, 2);
     }
     m_initPosForSplit = QPointF();


### PR DESCRIPTION
cancel trigger splitswap when click browser

Log: cancel trigger splitswap when click browser

Bug: https://pms.uniontech.com/bug-view-271909.html