### PR TITLE
fix: the function of maxi/restor invalid on touchpad with three fingers

### DIFF
--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -221,7 +221,7 @@ Workspace::Workspace()
     new DBusInterface(this);
 
     QDBusConnection::sessionBus().connect(QString(), QString(), DBUS_DEEPIN_WM_INTF, "QuickTileWindow", this, SLOT(tileActiveWindow(uint)));
-    QDBusConnection::sessionBus().connect(QString(), QString(), DBUS_DEEPIN_WM_INTF, "WindowMaximize", this, SLOT(toggleActiveMaximize()));
+    QDBusConnection::sessionBus().connect(QString(), QString(), DBUS_DEEPIN_WM_INTF, "ToggleActiveWindowMaximizeChanged", this, SLOT(toggleActiveMaximize()));
 }
 
 void Workspace::init()


### PR DESCRIPTION
the function of maxi/restor invalid on touchpad with three fingers

Log: the function of maxi/restor invalid on touchpad with three fingers

Bug: https://pms.uniontech.com/bug-view-273125.html