### PR TITLE
feat: Refactor compositing teardown in X11Window and Unmanaged

### DIFF
--- a/src/backends/x11/standalone/x11_standalone_glx_backend.cpp
+++ b/src/backends/x11/standalone/x11_standalone_glx_backend.cpp
@@ -950,6 +950,9 @@ bool GlxPixmapTexturePrivate::create(SurfacePixmapX11 *texture)
         0};
 
     m_glxPixmap = glXCreatePixmap(m_backend->display(), info.fbconfig, texture->pixmap(), attrs);
+    if (m_glxPixmap <= 0) {
+        qCCritical(KWIN_X11STANDALONE) << "glXCreatePixmap failed, pixmap" << texture->pixmap();
+    }
     m_size = texture->size();
     m_yInverted = info.y_inverted ? true : false;
     m_canUseMipmaps = false;

--- a/src/scene/surfaceitem_x11.cpp
+++ b/src/scene/surfaceitem_x11.cpp
@@ -41,7 +41,7 @@ SurfaceItemX11::SurfaceItemX11(Window *window, Scene *scene, Item *parent)
 
 SurfaceItemX11::~SurfaceItemX11()
 {
-    // destroyDamage() will be called by the associated Window.
+    destroyDamage();
 }
 
 Window *SurfaceItemX11::window() const
@@ -127,6 +127,13 @@ void SurfaceItemX11::waitForDamage()
 
     addDamage(region);
     m_isDamaged = false;
+}
+
+void SurfaceItemX11::forgetDamage()
+{
+    // If the window is destroyed, we cannot destroy XDamage handle. :/
+    m_isDamaged = false;
+    m_damageHandle = XCB_NONE;
 }
 
 void SurfaceItemX11::destroyDamage()

--- a/src/scene/surfaceitem_x11.h
+++ b/src/scene/surfaceitem_x11.h
@@ -34,6 +34,7 @@ public:
     void processDamage();
     bool fetchDamage();
     void waitForDamage();
+    void forgetDamage();
     void destroyDamage();
 
     QVector<QRectF> shape() const override;

--- a/src/unmanaged.cpp
+++ b/src/unmanaged.cpp
@@ -149,6 +149,13 @@ bool Unmanaged::track(xcb_window_t w)
 
 void Unmanaged::release(ReleaseReason releaseReason)
 {
+    if (SurfaceItemX11 *item = qobject_cast<SurfaceItemX11 *>(surfaceItem())) {
+        if (releaseReason == ReleaseReason::Destroyed) {
+            item->forgetDamage();
+        } else {
+            item->destroyDamage();
+        }
+    }
     Deleted *del = nullptr;
     if (releaseReason != ReleaseReason::KWinShutsDown) {
         del = Deleted::create(this);
@@ -157,7 +164,6 @@ void Unmanaged::release(ReleaseReason releaseReason)
         Q_EMIT workspace()->preRemoveInternalWindow(this);
     }
     Q_EMIT windowClosed(this, del);
-    finishCompositing(releaseReason);
     if (!QWidget::find(window()) && releaseReason != ReleaseReason::Destroyed) { // don't affect our own windows
         if (Xcb::Extensions::self()->isShapeAvailable()) {
             xcb_shape_select_input(kwinApp()->x11Connection(), window(), false);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -33,7 +33,6 @@
 #include "tabbox.h"
 #endif
 #include "scene/shadowitem.h"
-#include "scene/surfaceitem_x11.h"
 #include "scene/windowitem.h"
 #include "screenedge.h"
 #include "shadow.h"
@@ -385,14 +384,8 @@ bool Window::setupCompositing()
     return true;
 }
 
-void Window::finishCompositing(ReleaseReason releaseReason)
+void Window::finishCompositing()
 {
-    // If the X11 window has been destroyed, avoid calling XDamageDestroy.
-    if (releaseReason != ReleaseReason::Destroyed) {
-        if (SurfaceItemX11 *item = qobject_cast<SurfaceItemX11 *>(surfaceItem())) {
-            item->destroyDamage();
-        }
-    }
     m_shadow.reset();
     m_effectWindow.reset();
     m_windowItem.reset();

--- a/src/window.h
+++ b/src/window.h
@@ -776,7 +776,7 @@ public:
     int depth() const;
     bool hasAlpha() const;
     virtual bool setupCompositing();
-    virtual void finishCompositing(ReleaseReason releaseReason = ReleaseReason::Release);
+    virtual void finishCompositing();
     // these call workspace->addRepaint(), but first transform the damage if needed
     void addWorkspaceRepaint(const QRectF &r);
     void addWorkspaceRepaint(int x, int y, int w, int h);

--- a/src/x11window.h
+++ b/src/x11window.h
@@ -215,7 +215,7 @@ public:
     bool hiddenPreview() const; ///< Window is mapped in order to get a window pixmap
 
     bool setupCompositing() override;
-    void finishCompositing(ReleaseReason releaseReason = ReleaseReason::Release) override;
+    void finishCompositing() override;
     void setBlockingCompositing(bool block);
     inline bool isBlockingCompositing()
     {


### PR DESCRIPTION
Currently, X11Window and Unmanaged call finishCompositing(), which tries to destroy the window item and other associated compositing data.

Usually, it has no any effect on the window item and the effect window because they are moved to the Deleted. However, it has some effect on the XDamage handle.

If the X11 window is unmapped, it will destroy the XDamage handle. If the X11 window is destroyed, it will do nothing. Why does it behave like that? Because that's how the XDamage spec is written.

This change removes the call to finishCompositing() and refactors how the XDamage is handled so Window::finishCompositing() is more generic.

If the X11 window is destroyed, SurfaceItemX11::forgetDamage() will be called and SurfaceItemX11::~SurfaceItemX11() won't attempt to destroy the damage handle.

If the X11 window is unmapped, SurfaceItemX11::destroyDamage() will be called and destroyDamage() in SurfaceItemX11::~SurfaceItemX11() will noop.

If compositing has been restarted, destroyDamage() in SurfaceItemX11::~SurfaceItemX11() will destroy the damage handle.

Bug: https://pms.uniontech.com/bug-view-254771.html
Log: Fix window black in x11 mode

Change-Id: Ie77c7db2db7968d65717d9e38c5b773f3e4bbfa4