### PR TITLE
fix: install kwin deb fail when iso build

### DIFF
--- a/debian/deepin-kwin-x11.postinst
+++ b/debian/deepin-kwin-x11.postinst
@@ -49,6 +49,14 @@ function deleteKeyConfigfile() {
     done
 }
 
+if [ ! -d /home/ ]; then
+    exit 0
+fi
+
+if [ ! "$(ls -A "/home/")" ]; then
+    exit 0
+fi
+
 user_dirs=$(ls -d /home/*)
 for dir in $user_dirs; do
     user=$(basename $dir)


### PR DESCRIPTION
install kwin deb fail when iso build

Log: install kwin deb fail when iso build