### PR TITLE
backends/x11: fix colormap leak

### DIFF
--- a/src/backends/x11/standalone/x11_standalone_glx_backend.cpp
+++ b/src/backends/x11/standalone/x11_standalone_glx_backend.cpp
@@ -126,6 +126,7 @@ GlxBackend::GlxBackend(Display *display, X11StandaloneBackend *backend)
     , window(None)
     , fbconfig(nullptr)
     , glxWindow(None)
+    , m_colormap(XCB_COLORMAP_NONE)
     , ctx(nullptr)
     , m_bufferAge(0)
     , m_x11Display(display)
@@ -158,6 +159,11 @@ GlxBackend::~GlxBackend()
 
     if (ctx) {
         glXDestroyContext(display(), ctx);
+    }
+
+    if (m_colormap != XCB_COLORMAP_NONE) {
+        xcb_free_colormap(connection(), m_colormap);
+        m_colormap = XCB_COLORMAP_NONE;
     }
 
     if (glxWindow) {
@@ -453,15 +459,15 @@ bool GlxBackend::initBuffer()
             return false;
         }
 
-        xcb_colormap_t colormap = xcb_generate_id(c);
-        xcb_create_colormap(c, false, colormap, rootWindow(), visual);
+        m_colormap = xcb_generate_id(c);
+        xcb_create_colormap(c, false, m_colormap, rootWindow(), visual);
 
         const QSize size = workspace()->geometry().size();
 
         window = xcb_generate_id(c);
         xcb_create_window(c, visualDepth(visual), window, overlayWindow()->window(),
                           0, 0, size.width(), size.height(), 0, XCB_WINDOW_CLASS_INPUT_OUTPUT,
-                          visual, XCB_CW_COLORMAP, &colormap);
+                          visual, XCB_CW_COLORMAP, &m_colormap);
 
         glxWindow = glXCreateWindow(display(), fbconfig, window, nullptr);
         overlayWindow()->setup(window);

--- a/src/backends/x11/standalone/x11_standalone_glx_backend.h
+++ b/src/backends/x11/standalone/x11_standalone_glx_backend.h
@@ -117,6 +117,7 @@ private:
     ::Window window;
     GLXFBConfig fbconfig;
     GLXWindow glxWindow;
+    xcb_colormap_t m_colormap;
     GLXContext ctx;
     QHash<xcb_visualid_t, FBConfigInfo> m_fbconfigHash;
     QHash<xcb_visualid_t, int> m_visualDepthHash;


### PR DESCRIPTION
If we change the backend or restart compositor the colormap will get leak, the colormap should be released by xcb_free_colormap before the window destoryed.

Bug: https://pms.uniontech.com/bug-view-264449.html
Log: Fix screen block issue


Change-Id: I20c4626d0ed288797cb40014fa76fccd016339a9