### PR TITLE
fix: Don't show workspace preview when count max

### DIFF
--- a/src/composite.cpp
+++ b/src/composite.cpp
@@ -1203,10 +1203,10 @@ void X11Compositor::start()
             m_effectType = EffectType::XRenderComplete;
         }
         setDConfigUserEffectType(m_effectType);
-        qCDebug(KWIN_CORE) << "Effect type is automatically set to" << m_effectType;
+        qCWarning(KWIN_CORE) << "Effect type is automatically set to" << m_effectType;
     }
 
-    qCDebug(KWIN_CORE) << "Current effect type:" << m_effectType;
+    qCWarning(KWIN_CORE) << "Current effect type:" << m_effectType;
 
     if (m_effectType == EffectType::NoneCompositor) {
         qCDebug(KWIN_CORE) << "Compositing is disabled by DConfig";

--- a/src/effects/multitaskview/multitaskview.cpp
+++ b/src/effects/multitaskview/multitaskview.cpp
@@ -3048,6 +3048,8 @@ void MultitaskViewEffect::addNewDesktop()
     int count = effects->numberOfDesktops();
     if (count >= MAX_DESKTOP_COUNT)
         return;
+    if (count == MAX_DESKTOP_COUNT - 1)
+        m_isShowPreview = false;
 
     m_isShieldEvent = true;
     effects->setNumberOfDesktops(count + 1);


### PR DESCRIPTION
Don't show workspace preview when count max

Log: Don't show workspace preview when count max

Bug: https://pms.uniontech.com/bug-view-287273.html