### PR TITLE
feat: make dock can use systemResize

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1277,7 +1277,7 @@ void X11Window::NETMoveResize(qreal x_root, qreal y_root, NET::Direction directi
             Gravity::Bottom,
             Gravity::BottomLeft,
             Gravity::Left};
-        if (!isResizable() || isShade()) {
+        if ((!isDock() && !isResizable()) || isShade()) {
             return;
         }
         if (isInteractiveMoveResize()) {
@@ -1286,7 +1286,7 @@ void X11Window::NETMoveResize(qreal x_root, qreal y_root, NET::Direction directi
         setInteractiveMoveResizePointerButtonDown(true);
         setInteractiveMoveOffset(QPointF(x_root - x(), y_root - y())); // map from global
         setInvertedInteractiveMoveOffset(rect().bottomRight() - interactiveMoveOffset());
-        setUnrestrictedInteractiveMoveResize(false);
+        setUnrestrictedInteractiveMoveResize(isDock());
         setInteractiveMoveResizeGravity(convert[direction]);
         if (!startInteractiveMoveResize()) {
             setInteractiveMoveResizePointerButtonDown(false);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1961,7 +1961,7 @@ void Window::handleInteractiveMoveResize(int x, int y, int x_root, int y_root)
 
     const Gravity gravity = interactiveMoveResizeGravity();
     if ((gravity == Gravity::None && !isMovableAcrossScreens())
-        || (gravity != Gravity::None && (isShade() || !isResizable()))) {
+        || (gravity != Gravity::None && (isShade() || (!isDock() && !isResizable())))) {
         return;
     }
 
@@ -2959,7 +2959,7 @@ int Window::borderTop() const
 void Window::updateCursor()
 {
     Gravity gravity = interactiveMoveResizeGravity();
-    if (!isResizable() || isShade()) {
+    if ((!isDock() && !isResizable()) || isShade()) {
         gravity = Gravity::None;
     }
     CursorShape c = Qt::ArrowCursor;


### PR DESCRIPTION
X11 clients can use _NET_WM_MOVERESIZE to let the WM take charge of the resize operation, so as to have a smooth resize effect. However, the implementation in Kwin prohibits this behavior of special window by default. This will cause the dock to be unable to call this mechanism, resulting in a relatively poor drag and drop experience.

So in this PR, I released the _NET_WM_MOVERESIZE request for dock type windows. At the same time, when the window type is Dock, moveResize is set to a Unrestricted state to remove the influence of the exclusive area.

log: as title