### PR TITLE
fix: dxcb may not loaded in qt6

### DIFF
--- a/src/main_x11.cpp
+++ b/src/main_x11.cpp
@@ -388,7 +388,7 @@ int main(int argc, char *argv[])
     signal(SIGPIPE, SIG_IGN);
 
     // enforce xcb plugin, unfortunately command line switch has precedence
-    setenv("QT_QPA_PLATFORM", "xcb", true);
+    setenv("QT_QPA_PLATFORM", "dxcb;xcb", true);
 
     qunsetenv("QT_DEVICE_PIXEL_RATIO");
     qunsetenv("QT_SCALE_FACTOR");


### PR DESCRIPTION
Log: Load DPlatformIntegration::buildNativeSettings failed when use qxcb, should perfer dxcb then qxcb