### PR TITLE
fix: schedule repaint after call takeScreenShot

### DIFF
--- a/src/effects/screenshot/screenshotdbusinterface2.cpp
+++ b/src/effects/screenshot/screenshotdbusinterface2.cpp
@@ -7,6 +7,7 @@
 */
 
 #include "screenshotdbusinterface2.h"
+#include "composite.h"
 #include "screenshot2adaptor.h"
 #include "screenshotlogging.h"
 #include "utils/serviceutils.h"
@@ -176,6 +177,9 @@ ScreenShotSource2::ScreenShotSource2(const QFuture<QImage> &future)
     connect(m_watcher, &QFutureWatcher<QImage>::finished, this, &ScreenShotSource2::completed);
     connect(m_watcher, &QFutureWatcher<QImage>::canceled, this, &ScreenShotSource2::cancelled);
     m_watcher->setFuture(m_future);
+    // takeScreenShot will done in ScreenShotEffect::paintScreen
+    // if all windows are minmize, we must call scheduleRepaint actively
+    Compositor::self()->scheduleRepaint();
 }
 
 bool ScreenShotSource2::isCancelled() const


### PR DESCRIPTION
log: 当所有应用都最小化或者隐藏时，如果触发dock预览需要 kwin 提供对应 windows 截图 这一工作在ScreenShotEffect::paintScreen完成，如果桌面没有显示任何窗口，并且dock 被dbus block gui,那么 renderloop 就不会触发 paintScreen

https://github.com/linuxdeepin/deepin-kwin/pull/285