### PR TITLE
fix: hoverleave dde-dock preview,window show error

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1472,11 +1472,6 @@ void Window::minimize(bool avoid_animation)
 
 void Window::unminimize(bool avoid_animation)
 {
-    // Prevent window from being minimized after ending preview
-    if(!waylandServer()) {
-        setProperty("__deepin_kwin_minimized", QVariant());
-    }
-
     if (!isMinimized()) {
         return;
     }

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -3966,10 +3966,10 @@ void Workspace::setPreviewClientList(const QList<Window*> &list)
             if (!c->isDock() && !c->isDesktop()) {
                 if (list.contains(c)) {
                     if (c->isMinimized()) {
-                        // 记录窗口的最小化状态
-                        c->setProperty("__deepin_kwin_minimized", true);
                         // 恢复最小化以便预览窗口
                         c->unminimize(true);
+                        // 记录窗口的最小化状态
+                        c->setProperty("__deepin_kwin_minimized", true);
                     }
                 } else {
                     if (c->property("__deepin_kwin_minimized").toBool()) {


### PR DESCRIPTION
wrong __deepin_kwin_minimized property tag.

Log: hoverleave dde-dock preview,window show error
Issue: https://github.com/linuxdeepin/developer-center/issues/9488

CC @zzxyb @justforlxz 