### PR TITLE
fix(splitbar): can't show when use qt6

### DIFF
--- a/src/splitscreen/splitbar.cpp
+++ b/src/splitscreen/splitbar.cpp
@@ -34,6 +34,7 @@ SplitBar::SplitBar(QString screenName)
 
     setGeometry(0, 0, 1, 1);
     setWindowOpacity(0);
+    setCursor(Qt::SizeHorCursor);
     show();
     setProperty("__kwin_splitbar", true);
 }
@@ -56,10 +57,13 @@ void SplitBar::mouseReleaseEvent(QMouseEvent* e)
     Q_EMIT splitbarPosChanged(m_screenName, QPointF(), m_window, true);
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void SplitBar::enterEvent(QEvent *)
+#else
+void SplitBar::enterEvent(QEnterEvent *)
+#endif
 {
     setWindowOpacity(1);
-    setCursor(Qt::SizeHorCursor);
     workspace()->setSplitBarStatus(1);
     Q_EMIT workspace()->splitBarCursorChanged();
 }
@@ -68,7 +72,6 @@ void SplitBar::leaveEvent(QEvent *)
 {
     workspace()->setSplitBarStatus(0);
     setWindowOpacity(0);
-    setCursor(Qt::ArrowCursor);
 }
 
 void SplitBar::paintEvent(QPaintEvent *event)

--- a/src/splitscreen/splitbar.h
+++ b/src/splitscreen/splitbar.h
@@ -27,12 +27,16 @@ public:
     SplitBar(QString);
     ~SplitBar();
 
-    void mousePressEvent(QMouseEvent* e);
-    void mouseMoveEvent(QMouseEvent*e);
-    void mouseReleaseEvent(QMouseEvent* e);
-    void enterEvent(QEvent *);
-    void leaveEvent(QEvent *);
-    void paintEvent(QPaintEvent *event);
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEvent *) override;
+#else
+    void enterEvent(QEnterEvent *) override;
+#endif
+    void leaveEvent(QEvent *) override;
+    void paintEvent(QPaintEvent *event) override;
 
 Q_SIGNALS:
     void splitbarPosChanged(QString, QPointF, Window *, bool);


### PR DESCRIPTION
Log: enterEvent(QEvent *)  has changed to enterEvent(QEnterEvent *) in qt6, mark func as `override` is is really important