### PR TITLE
fix: get scale by devicePixelRatio when use qt6

### DIFF
--- a/src/effects/blur/blur.cpp
+++ b/src/effects/blur/blur.cpp
@@ -491,7 +491,12 @@ GLTexture *BlurEffect::ensureNoiseTexture()
         return nullptr;
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     const qreal scale = std::max(1.0, QGuiApplication::primaryScreen()->logicalDotsPerInch() / 96.0);
+#else
+    const qreal scale = std::max(1.0, QGuiApplication::primaryScreen()->devicePixelRatio());
+#endif
+
     if (!m_noisePass.noiseTexture || m_noisePass.noiseTextureScale != scale || m_noisePass.noiseTextureStength != m_noiseStrength) {
         // Init randomness based on time
         std::srand((uint)QTime::currentTime().msec());

--- a/src/effects/multitaskview/multitaskview.cpp
+++ b/src/effects/multitaskview/multitaskview.cpp
@@ -777,8 +777,11 @@ void MultitaskViewEffect::reconfigure(ReconfigureFlags flags)
     m_curDesktopIndex = effects->currentDesktop();
     m_lastDesktopIndex = m_curDesktopIndex;
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     m_scalingFactor = qMax(1.0, QGuiApplication::primaryScreen()->logicalDotsPerInch() / 96.0);
-
+#else
+    m_scalingFactor = qMax(1.0, QGuiApplication::primaryScreen()->devicePixelRatio());
+#endif
     KConfigGroup config_group(KSharedConfig::openConfig("kwinrc"), "Compositing");
     if (effects->waylandDisplay()) {
         setMotionEffect(config_group.readEntry("MultitaskViewMotionEffect", true));

--- a/src/plugins/kdecorations/deepin-chameleon/chameleonwindowtheme.cpp
+++ b/src/plugins/kdecorations/deepin-chameleon/chameleonwindowtheme.cpp
@@ -164,7 +164,11 @@ void ChameleonWindowTheme::updateScreen()
 
 void ChameleonWindowTheme::updateScreenScale()
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     qreal scale = m_screen->logicalDotsPerInch() / 96.0f;
+#else
+    qreal scale = m_screen->devicePixelRatio();
+#endif
 
     if (qFuzzyCompare(scale, m_windowPixelRatio))
         return;

--- a/src/pointer_input.cpp
+++ b/src/pointer_input.cpp
@@ -1125,7 +1125,11 @@ WaylandCursorImage::WaylandCursorImage(QObject *parent)
     : QObject(parent)
 {
     Cursor *pointerCursor = Cursors::self()->mouse();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     m_scale = qMax(1.0, QGuiApplication::primaryScreen()->logicalDotsPerInch() / 96.0);
+#else
+    m_scale = qMax(1.0, QGuiApplication::primaryScreen()->devicePixelRatio());
+#endif
     updateCursorTheme();
 
     connect(pointerCursor, &Cursor::themeChanged, this, &WaylandCursorImage::updateCursorTheme);

--- a/src/splitscreen/splitmenu.cpp
+++ b/src/splitscreen/splitmenu.cpp
@@ -46,7 +46,11 @@ SplitMenu::SplitMenu()
     }
     setAttribute(Qt::WA_TranslucentBackground);
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     m_scale = QGuiApplication::primaryScreen()->logicalDotsPerInch() / 96;
+#else
+    m_scale = QGuiApplication::primaryScreen()->devicePixelRatio();
+#endif
 
     setWindowTitle("splitmenu");
 

--- a/src/useractions.cpp
+++ b/src/useractions.cpp
@@ -208,7 +208,11 @@ void UserActionsMenu::prepareMenu(Window *cl)
     QString backgroundColor = workspace()->self()->getBlurStatus() ? "#cceeeeee" : "rgba(253,253,254,100%)";
     QString fontColor = "black";
     QString disableFontColor = "rgba(0,0,0,40%)";
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     qreal scalingFactor = qMax(1.0, QGuiApplication::primaryScreen()->logicalDotsPerInch() / 96.0);
+#else
+    qreal scalingFactor = qMax(1.0, QGuiApplication::primaryScreen()->devicePixelRatio());
+#endif
     QString fontSize = QString::number(int(fontScale * 14.0 * scalingFactor)) + "px";
     QString rightPadding = QString::number(45 * fontScale * fontScale * scalingFactor) + "px";
     if (workspace()->self()->isDarkTheme()) {

--- a/src/windowstyle/windowstylemanager.cpp
+++ b/src/windowstyle/windowstylemanager.cpp
@@ -44,7 +44,11 @@ WindowStyleManager::WindowStyleManager()
     connect(m_radiusConfig.get(), &ConfigReader::sigPropertyChanged, this, &WindowStyleManager::onRadiusChange);
     connect(m_themeConfig.get(), &ConfigReader::sigPropertyChanged, this, &WindowStyleManager::onThemeChange);
     connect(Compositor::self(), &Compositor::compositingToggled, this, &WindowStyleManager::onCompositingChanged);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     m_scale = qMax(1.0, QGuiApplication::primaryScreen()->logicalDotsPerInch() / 96.0);
+#else
+    m_scale = qMax(1.0, QGuiApplication::primaryScreen()->devicePixelRatio());
+#endif
 }
 
 WindowStyleManager::~WindowStyleManager()


### PR DESCRIPTION
log: logicalDotsPerInch() / 96.0 always get 1.0log: logicalDotsPerInch() / 96.0 always get 1.0, see https://blog.csdn.net/gongjianbo1992/article/details/135128484