### PR TITLE
fix: rename effects file name to mate id 

### DIFF
--- a/src/effects/magiclamp/CMakeLists.txt
+++ b/src/effects/magiclamp/CMakeLists.txt
@@ -17,6 +17,10 @@ target_link_libraries(kwin4_effect_magiclamp PRIVATE
     KF${KF_MAJOR_VERSION}::ConfigGui
 )
 
+set_target_properties(kwin4_effect_magiclamp PROPERTIES
+    LIBRARY_OUTPUT_NAME "magiclamp"
+)
+
 #######################################
 # Config
 if (KWIN_BUILD_KCMS)

--- a/src/effects/magnifier/CMakeLists.txt
+++ b/src/effects/magnifier/CMakeLists.txt
@@ -20,6 +20,9 @@ target_link_libraries(kwin4_effect_magnifier PRIVATE
     KF${KF_MAJOR_VERSION}::GlobalAccel
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_magnifier PROPERTIES
+    LIBRARY_OUTPUT_NAME "magnifier"
+)
 
 #######################################
 # Config

--- a/src/effects/maximizeex/CMakeLists.txt
+++ b/src/effects/maximizeex/CMakeLists.txt
@@ -17,6 +17,9 @@ target_link_libraries(kwin4_effect_maximizeex PRIVATE
     Qt${QT_MAJOR_VERSION}::DBus
     KF${KF_MAJOR_VERSION}::ConfigGui
 )
+set_target_properties(kwin4_effect_maximizeex PROPERTIES
+    LIBRARY_OUTPUT_NAME "maximizeex"
+)
 
 if (QT_MAJOR_VERSION EQUAL "5")
     target_link_libraries(kwin4_effect_maximizeex PRIVATE Qt5::X11Extras)

--- a/src/effects/mouseclick/CMakeLists.txt
+++ b/src/effects/mouseclick/CMakeLists.txt
@@ -19,6 +19,9 @@ target_link_libraries(kwin4_effect_mouseclick PRIVATE
     KF${KF_MAJOR_VERSION}::GlobalAccel
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_mouseclick PROPERTIES
+    LIBRARY_OUTPUT_NAME "mouseclick"
+)
 
 ##########################
 ## configurtion dialog

--- a/src/effects/mousemark/CMakeLists.txt
+++ b/src/effects/mousemark/CMakeLists.txt
@@ -19,6 +19,9 @@ target_link_libraries(kwin4_effect_mousemark PRIVATE
     KF${KF_MAJOR_VERSION}::GlobalAccel
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_mousemark PROPERTIES
+    LIBRARY_OUTPUT_NAME "mousemark"
+)
 
 #######################################
 # Config

--- a/src/effects/multitaskview/CMakeLists.txt
+++ b/src/effects/multitaskview/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(kwin4_effect_multitaskview PRIVATE
     Qt${QT_MAJOR_VERSION}::Concurrent
     PkgConfig::QGSETTINGS
 )
+set_target_properties(kwin4_effect_multitaskview PROPERTIES
+    LIBRARY_OUTPUT_NAME "multitaskview"
+)
 
 if (QT_MAJOR_VERSION EQUAL "5")
     target_link_libraries(kwin4_effect_multitaskview PRIVATE Qt5::X11Extras)

--- a/src/effects/outputlocator/CMakeLists.txt
+++ b/src/effects/outputlocator/CMakeLists.txt
@@ -10,5 +10,8 @@ target_link_libraries(kwin4_effect_outputlocator PRIVATE
     Qt${QT_MAJOR_VERSION}::Quick
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_outputlocator PROPERTIES
+    LIBRARY_OUTPUT_NAME "outputlocator"
+)
 
 install(DIRECTORY qml DESTINATION ${KDE_INSTALL_DATADIR}/kwin/effects/outputlocator)

--- a/src/effects/overview/CMakeLists.txt
+++ b/src/effects/overview/CMakeLists.txt
@@ -25,5 +25,9 @@ target_link_libraries(kwin4_effect_overview PRIVATE
 
     Qt${QT_MAJOR_VERSION}::Quick
 )
+set_target_properties(kwin4_effect_overview PROPERTIES
+    LIBRARY_OUTPUT_NAME "overview"
+)
+
 
 install(DIRECTORY qml DESTINATION ${KDE_INSTALL_DATADIR}/kwin/effects/overview)

--- a/src/effects/scissorwindow/CMakeLists.txt
+++ b/src/effects/scissorwindow/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(kwin4_effect_scissorwindow PRIVATE
     Qt${QT_MAJOR_VERSION}::Core
     Qt${QT_MAJOR_VERSION}::QuickWidgets
 )
+set_target_properties(kwin4_effect_scissorwindow PROPERTIES
+    LIBRARY_OUTPUT_NAME "scissorwindow"
+)

--- a/src/effects/screenedge/CMakeLists.txt
+++ b/src/effects/screenedge/CMakeLists.txt
@@ -12,6 +12,9 @@ target_link_libraries(kwin4_effect_screenedge PRIVATE
     kwineffects
     kwinglutils
 )
+set_target_properties(kwin4_effect_screenedge PROPERTIES
+    LIBRARY_OUTPUT_NAME "screenedge"
+)
 
 if (QT_MAJOR_VERSION EQUAL "5")
     target_link_libraries(kwin4_effect_screenedge PRIVATE KF5::Plasma)

--- a/src/effects/screenshot/CMakeLists.txt
+++ b/src/effects/screenshot/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(kwin4_effect_screenshot PRIVATE
     Qt${QT_MAJOR_VERSION}::DBus
     Qt${QT_MAJOR_VERSION}::QuickWidgets
 )
+set_target_properties(kwin4_effect_screenshot PROPERTIES
+    LIBRARY_OUTPUT_NAME "screenshot"
+)
 
 if (QT_MAJOR_VERSION EQUAL "5")
     target_link_libraries(kwin4_effect_screenshot PRIVATE Qt5::X11Extras)

--- a/src/effects/screentransform/CMakeLists.txt
+++ b/src/effects/screentransform/CMakeLists.txt
@@ -12,3 +12,6 @@ target_link_libraries(kwin4_effect_screentransform PRIVATE
     kwineffects
     kwinglutils
 )
+set_target_properties(kwin4_effect_screentransform PROPERTIES
+    LIBRARY_OUTPUT_NAME "screentransform"
+)

--- a/src/effects/sheet/CMakeLists.txt
+++ b/src/effects/sheet/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(kwin4_effect_sheet PRIVATE
     KF${KF_MAJOR_VERSION}::ConfigGui
     Qt${QT_MAJOR_VERSION}::QuickWidgets
 )
+set_target_properties(kwin4_effect_sheet PROPERTIES
+    LIBRARY_OUTPUT_NAME "sheet"
+)

--- a/src/effects/showfps/CMakeLists.txt
+++ b/src/effects/showfps/CMakeLists.txt
@@ -11,10 +11,12 @@ kwin4_add_effect_module(kwin4_effect_showfps ${showfps_SOURCES})
 
 target_link_libraries(kwin4_effect_showfps PRIVATE
     kwineffects
-
     KF${KF_MAJOR_VERSION}::I18n
-
     Qt${QT_MAJOR_VERSION}::Quick
-    )
+)
+ 
+set_target_properties(kwin4_effect_showfps PROPERTIES
+    LIBRARY_OUTPUT_NAME "showfps"
+)
 
 install(DIRECTORY qml DESTINATION ${KDE_INSTALL_DATADIR}/kwin/effects/showfps)

--- a/src/effects/showpaint/CMakeLists.txt
+++ b/src/effects/showpaint/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(kwin4_effect_showpaint PRIVATE
     KF${KF_MAJOR_VERSION}::GlobalAccel
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_showpaint PROPERTIES
+    LIBRARY_OUTPUT_NAME "showpaint"
+)
 
 #######################################
 # Config

--- a/src/effects/slide/CMakeLists.txt
+++ b/src/effects/slide/CMakeLists.txt
@@ -17,6 +17,9 @@ target_link_libraries(kwin4_effect_slide PRIVATE
 
     KF${KF_MAJOR_VERSION}::ConfigGui
 )
+set_target_properties(kwin4_effect_slide PROPERTIES
+    LIBRARY_OUTPUT_NAME "slide"
+)
 
 #######################################
 # Config

--- a/src/effects/slideback/CMakeLists.txt
+++ b/src/effects/slideback/CMakeLists.txt
@@ -11,3 +11,6 @@ kwin4_add_effect_module(kwin4_effect_slideback ${slideback_SOURCES})
 target_link_libraries(kwin4_effect_slideback PRIVATE
     kwineffects
 )
+set_target_properties(kwin4_effect_slideback PROPERTIES
+    LIBRARY_OUTPUT_NAME "slideback"
+)

--- a/src/effects/slidingpopups/CMakeLists.txt
+++ b/src/effects/slidingpopups/CMakeLists.txt
@@ -18,3 +18,7 @@ target_link_libraries(kwin4_effect_slidingpopups PRIVATE
 
     KF${KF_MAJOR_VERSION}::ConfigGui
 )
+
+set_target_properties(kwin4_effect_slidingpopups PROPERTIES
+    LIBRARY_OUTPUT_NAME "slidingpopups"
+)

--- a/src/effects/snaphelper/CMakeLists.txt
+++ b/src/effects/snaphelper/CMakeLists.txt
@@ -13,3 +13,6 @@ target_link_libraries(kwin4_effect_snaphelper PRIVATE
     kwinglutils
     Qt${QT_MAJOR_VERSION}::QuickWidgets
 )
+set_target_properties(kwin4_effect_snaphelper PROPERTIES
+    LIBRARY_OUTPUT_NAME "snaphelper"
+)

--- a/src/effects/splitscreen/CMakeLists.txt
+++ b/src/effects/splitscreen/CMakeLists.txt
@@ -17,6 +17,9 @@ target_link_libraries(kwin4_effect_splitscreen PRIVATE
     Qt${QT_MAJOR_VERSION}::DBus
     KF${KF_MAJOR_VERSION}::ConfigGui
 )
+set_target_properties(kwin4_effect_splitscreen PROPERTIES
+    LIBRARY_OUTPUT_NAME "splitscreen"
+)
 
 if (QT_MAJOR_VERSION EQUAL "5")
     target_link_libraries(kwin4_effect_splitscreen PRIVATE Qt5::X11Extras)

--- a/src/effects/splitswap/CMakeLists.txt
+++ b/src/effects/splitswap/CMakeLists.txt
@@ -17,6 +17,9 @@ target_link_libraries(kwin4_effect_splitswap PRIVATE
     Qt${QT_MAJOR_VERSION}::DBus
     KF${KF_MAJOR_VERSION}::ConfigGui
 )
+set_target_properties(kwin4_effect_splitswap PROPERTIES
+    LIBRARY_OUTPUT_NAME "splitswap"
+)
 
 if (QT_MAJOR_VERSION EQUAL "5")
     target_link_libraries(kwin4_effect_splitswap PRIVATE Qt5::X11Extras)

--- a/src/effects/startupfeedback/CMakeLists.txt
+++ b/src/effects/startupfeedback/CMakeLists.txt
@@ -16,3 +16,6 @@ target_link_libraries(kwin4_effect_startupfeedback PRIVATE
     Qt${QT_MAJOR_VERSION}::DBus
     Qt${QT_MAJOR_VERSION}::Widgets
 )
+set_target_properties(kwin4_effect_startupfeedback PROPERTIES
+    LIBRARY_OUTPUT_NAME "startupfeedback"
+)

--- a/src/effects/thumbnailaside/CMakeLists.txt
+++ b/src/effects/thumbnailaside/CMakeLists.txt
@@ -19,6 +19,9 @@ target_link_libraries(kwin4_effect_thumbnailaside PRIVATE
     KF${KF_MAJOR_VERSION}::GlobalAccel
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_thumbnailaside PROPERTIES
+    LIBRARY_OUTPUT_NAME "thumbnailaside"
+)
 
 #######################################
 # Config

--- a/src/effects/tileseditor/CMakeLists.txt
+++ b/src/effects/tileseditor/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(kwin4_effect_tileseditor PRIVATE
     KF${KF_MAJOR_VERSION}::I18n
 
     Qt${QT_MAJOR_VERSION}::Quick
-    )
+)
+set_target_properties(kwin4_effect_tileseditor PROPERTIES
+    LIBRARY_OUTPUT_NAME "tileseditor"
+)
 
 install(DIRECTORY qml DESTINATION ${KDE_INSTALL_DATADIR}/kwin/effects/tileseditor)

--- a/src/effects/touchpoints/CMakeLists.txt
+++ b/src/effects/touchpoints/CMakeLists.txt
@@ -13,3 +13,6 @@ target_link_libraries(kwin4_effect_touchpoints PRIVATE
 
     KF${KF_MAJOR_VERSION}::GlobalAccel
 )
+set_target_properties(kwin4_effect_touchpoints PROPERTIES
+    LIBRARY_OUTPUT_NAME "touchpoints"
+)

--- a/src/effects/trackmouse/CMakeLists.txt
+++ b/src/effects/trackmouse/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(kwin4_effect_trackmouse PRIVATE
     KF${KF_MAJOR_VERSION}::GlobalAccel
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_trackmouse PROPERTIES
+    LIBRARY_OUTPUT_NAME "trackmouse"
+)
 
 #######################################
 # Config

--- a/src/effects/wobblywindows/CMakeLists.txt
+++ b/src/effects/wobblywindows/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(kwin4_effect_wobblywindows PRIVATE
 
     KF${KF_MAJOR_VERSION}::ConfigGui
 )
+set_target_properties(kwin4_effect_wobblywindows PROPERTIES
+    LIBRARY_OUTPUT_NAME "wobblywindows"
+)
 
 #######################################
 # Config

--- a/src/effects/zoom/CMakeLists.txt
+++ b/src/effects/zoom/CMakeLists.txt
@@ -26,6 +26,9 @@ target_link_libraries(kwin4_effect_zoom PRIVATE
     KF${KF_MAJOR_VERSION}::GlobalAccel
     KF${KF_MAJOR_VERSION}::I18n
 )
+set_target_properties(kwin4_effect_zoom PROPERTIES
+    LIBRARY_OUTPUT_NAME "zoom"
+)
 
 if (HAVE_ACCESSIBILITY)
     target_include_directories(kwin4_effect_zoom PRIVATE ${QACCESSIBILITYCLIENT_INCLUDE_DIR})


### PR DESCRIPTION
Log: The Id field from the KPlugin object in the metadata should be removed in kf6
Same with https://github.com/linuxdeepin/deepin-kwin/commit/29452fa32a2560c58562cab329f9974b6dd60523