### PR TITLE
chore(effects): rename kwin4_effect_magiclamp to magiclamp

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-kwin (4:6.0.6) unstable; urgency=medium
+
+  * chore(effects): rename kwin4_effect_magiclamp to magiclamp
+  * fix: add judge about mouseInputAreaMargin from dtk win in isResizable
+  * fix: add listener for scale change
+  * fix: force launcher size to be set to screen size
+  * chore(splitscreen): remove unsed PlasmaCore
+
+ -- rewine <luhongxu@deepin.org>  Wed, 23 Apr 2025 15:04:11 +0800
+
 deepin-kwin (4:6.0.5) unstable; urgency=medium
 
   * fix: INSTALL_NAMESPACE error for windowswitche

--- a/src/effects/magiclamp/CMakeLists.txt
+++ b/src/effects/magiclamp/CMakeLists.txt
@@ -10,8 +10,9 @@ kconfig_add_kcfg_files(magiclamp_SOURCES
     magiclampconfig.kcfgc
 )
 
-kwin4_add_effect_module(kwin4_effect_magiclamp ${magiclamp_SOURCES})
-target_link_libraries(kwin4_effect_magiclamp PRIVATE
+kwin4_add_effect_module(magiclamp ${magiclamp_SOURCES})
+
+target_link_libraries(magiclamp PRIVATE
     kwineffects
 
     KF${KF_MAJOR_VERSION}::ConfigGui


### PR DESCRIPTION
Log: kf6 use file name to find effects, not check id in metadata.json now
Use `qdbus org.kde.KWin /Effects org.kde.kwin.Effects.listOfEffects` to check