### PR TITLE
chore: Update README files for Deepin KWin Qt6/KF6 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,27 @@
-# KWin
+# Deepin KWin
 
-KWin is an easy to use, but flexible, composited Window Manager for Xorg windowing systems (Wayland, X11) on Linux. Its primary usage is in conjunction with a Desktop Shell (e.g. KDE Plasma Desktop). KWin is designed to go out of the way; users should not notice that they use a window manager at all. Nevertheless KWin provides a steep learning curve for advanced features, which are available, if they do not conflict with the primary mission. KWin does not have a dedicated targeted user group, but follows the targeted user group of the Desktop Shell using KWin as it's window manager.
+deepin-kwin is deepin desktop environment's core window manager, customized based on KWin 5.27 with Qt6/KF6 support. KWin is an easy to use, but flexible, composited Window Manager for Xorg windowing systems (Wayland, X11) on Linux. Its primary usage is in conjunction with a Desktop Shell (e.g. KDE Plasma Desktop). KWin is designed to go out of the way; users should not notice that they use a window manager at all. Nevertheless KWin provides a steep learning curve for advanced features, which are available, if they do not conflict with the primary mission. KWin does not have a dedicated targeted user group, but follows the targeted user group of the Desktop Shell using KWin as it's window manager.
 
-## KWin is not...
+## Build Requirements
 
- * a standalone window manager (c.f. openbox, i3) and does not provide any functionality belonging to a Desktop Shell.
- * a replacement for window managers designed for use with a specific Desktop Shell (e.g. GNOME Shell)
- * a minimalistic window manager
- * designed for use without compositing or for X11 network transparency, though both are possible.
+- Qt 6.7+
+- KDE Frameworks 6.0+
+- XCB related development libraries
 
-# Contributing to KWin
+## Compilation & Installation
 
-Please refer to the [contributing document](CONTRIBUTING.md) for everything you need to know to get started contributing to KWin.
+```
+git clone https://github.com/linuxdeepin/deepin-kwin.git
+cd deepin-kwin
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build
+cmake --install build
+```
 
-# Contacting KWin development team
+## Getting Involved
 
- * mailing list: [kwin@kde.org](https://mail.kde.org/mailman/listinfo/kwin)
- * IRC: #kde-kwin on irc.libera.chat
-
-# Support
-## Application Developer
-If you are an application developer having questions regarding windowing systems (either X11 or Wayland) please do not hesitate to contact us. Preferable through our mailing list. Ideally subscribe to the mailing list, so that your mail doesn't get stuck in the moderation queue.
-
-## End user
-Please contact the support channels of your Linux distribution for user support. The KWin development team does not provide end user support.
-
-# Reporting bugs
-
-Please use [KDE's bugtracker](https://bugs.kde.org) and report for [product KWin](https://bugs.kde.org/enter_bug.cgi?product=kwin).
+- [Code contribution via GitHub](https://github.com/linuxdeepin/deepin-kwin/)
+- [Submit bug or suggestions to GitHub Issues or GitHub Discussions](https://github.com/linuxdeepin/developer-center/issues/new/choose)
 
 ## Guidelines for new features
 
@@ -47,3 +41,7 @@ A new Feature can only be added to KWin if:
 All new added features are under probation, that is if any of the non-functional requirements as listed above do not hold true in the next two feature releases, the added feature will be removed again.
 
 The same non functional requirements hold true for any kind of plugins (effects, scripts, etc.). It is suggested to use scripted plugins and distribute them separately.
+
+## License
+
+**deepin-kwin** is licensed under GPL-2.0-or-later.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -1,0 +1,48 @@
+# Deepin KWin
+
+deepin-kwin 是深度桌面环境的核心窗口管理器，基于 KWin 5.27 定制开发，支持 Qt6/KF6。KWin 是一个易于使用且灵活的 Linux 系统上的混成窗口管理器，支持 Wayland 和 X11 窗口系统。它主要与桌面外壳（如 KDE Plasma Desktop）配合使用。KWin 的设计理念是不引人注意；用户应该感觉不到他们正在使用窗口管理器。尽管如此，KWin 为高级功能提供了陡峭的学习曲线，这些功能在不与主要使命冲突的情况下可供使用。KWin 没有专门的目标用户群体，而是追随使用 KWin 作为窗口管理器的桌面外壳的目标用户群体。
+
+## 构建依赖
+
+- Qt 6.7+
+- KDE Frameworks 6.0+
+- XCB 相关开发库
+
+## 编译和安装
+
+```
+git clone https://github.com/linuxdeepin/deepin-kwin.git
+cd deepin-kwin
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build
+cmake --install build
+```
+
+## 参与贡献
+
+- [通过 GitHub 贡献代码](https://github.com/linuxdeepin/deepin-kwin/)
+- [在 GitHub Issues 或 GitHub Discussions 提交 bug 或建议](https://github.com/linuxdeepin/developer-center/issues/new/choose)
+
+## 新功能指南
+
+新功能只有在满足以下条件时才能被添加到 KWin：
+
+* 不违反本文档开头所述的主要使命
+* 不引入不稳定性
+* 得到维护，即 bug 能在及时修复（下下个小版本发布前），除非是极端情况
+* 能与所有现有功能协同工作
+* 支持单屏和多屏（xrandr）
+* 能带来显著优势
+* 功能完整，即至少支持竞争实现中所有有用的功能
+* 不是针对小用户群体的特殊情况
+* 不会显著增加代码复杂度
+* 不影响 KWin 的许可证（GPLv2+）
+
+所有新增功能都处于观察期，如果在接下来的两个功能版本中不满足上述任何非功能性要求，该功能将被移除。
+
+对于任何类型的插件（效果、脚本等）也同样适用这些非功能性要求。建议使用脚本插件并单独分发。
+
+## 许可证
+
+**deepin-kwin** 采用 GPL-2.0-or-later 许可证。
+


### PR DESCRIPTION
Update README.md and README.zh_CN.md with:
- Project scope clarification (Deepin KWin based on KWin 5.27 with Qt6/KF6 support)
- Updated build requirements and modern CMake workflow
- Standardized contribution guidelines and community links
- Translated technical content while preserving original KWin mission statement
- New feature guidelines and plugin requirements alignment
- License information standardization