### PR TITLE
fix: crash in OffscreenQuickView::update when rhi is null

### DIFF
--- a/src/libkwineffects/kwinoffscreenquickview.cpp
+++ b/src/libkwineffects/kwinoffscreenquickview.cpp
@@ -288,6 +288,11 @@ void OffscreenQuickView::update()
 #else
         d->m_view->setRenderTarget(QQuickRenderTarget::fromOpenGLTexture(d->m_fbo->texture(), d->m_fbo->size()));
 #endif
+        auto *rhi = d->m_renderControl->rhi();
+        if (!rhi) {
+           qCCritical(LIBKWINEFFECTS) << "Skipping render: QRhi is invalid";
+           return;
+        }
     }
 
     d->m_renderControl->polishItems();


### PR DESCRIPTION
This is merely a temporary workaround. On machines with NVIDIA dedicated GPUs that trigger a multi-display setup, a crash may occur due to a null RHI (Rendering Hardware Interface) pointer. Skipping this update can prevent the crash, though the side effect is that users may notice the loss of one frame update.