### PR TITLE
docs: fix plural forms header in Icelandic translation

### DIFF
--- a/po/is/kcm_kwin_virtualdesktops.po
+++ b/po/is/kcm_kwin_virtualdesktops.po
@@ -17,10 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Lokalize 22.08.3\n"
-"Plural-Forms: Plural-Forms: nplurals=2; plural=n != 1;\n"
-"\n"
-"\n"
-"\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #, kde-format
 msgctxt "NAME OF TRANSLATORS"


### PR DESCRIPTION
1. Corrected the Plural-Forms header by removing duplicated line and extra newlines
2. The header now properly specifies 2 plural forms with "n != 1" rule for Icelandic
3. This fixes potential issues with translation tools parsing the file incorrectly
4. The change ensures better compatibility with localization systems

docs: 修复冰岛语翻译中的复数形式头信息

1. 通过删除重复行和多余换行修正了 Plural-Forms 头信息
2. 现在头信息正确指定了冰岛语的两个复数形式规则 "n != 1"
3. 这解决了翻译工具解析文件时可能出现的问题
4. 此更改确保与本地化系统更好的兼容性